### PR TITLE
gthree: Mark public symbols to possibly exporting them

### DIFF
--- a/gthree/gthreeambientlight.h
+++ b/gthree/gthreeambientlight.h
@@ -26,7 +26,9 @@ typedef struct {
 
 } GthreeAmbientLightClass;
 
+GTHREE_API
 GthreeAmbientLight *gthree_ambient_light_new (const GdkRGBA *color);
+GTHREE_API
 GType gthree_ambient_light_get_type (void) G_GNUC_CONST;
 
 G_END_DECLS

--- a/gthree/gthreeanimationaction.h
+++ b/gthree/gthreeanimationaction.h
@@ -34,65 +34,99 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeAnimationAction, g_object_unref)
 
+GTHREE_API
 GType gthree_animation_action_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeAnimationAction * gthree_animation_action_new (GthreeAnimationMixer *mixer,
                                                      GthreeAnimationClip *clip,
                                                      GthreeObject *local_root);
 
+GTHREE_API
 void                  gthree_animation_action_play                     (GthreeAnimationAction *action);
+GTHREE_API
 void                  gthree_animation_action_stop                     (GthreeAnimationAction *action);
+GTHREE_API
 void                  gthree_animation_action_reset                    (GthreeAnimationAction *action);
+GTHREE_API
 void                  gthree_animation_action_set_enabled              (GthreeAnimationAction *action,
                                                                         gboolean               enabled);
+GTHREE_API
 gboolean              gthree_animation_action_get_enabled              (GthreeAnimationAction *action);
+GTHREE_API
 void                  gthree_animation_action_set_paused               (GthreeAnimationAction *action,
                                                                         gboolean               paused);
+GTHREE_API
 gboolean              gthree_animation_action_get_paused               (GthreeAnimationAction *action);
+GTHREE_API
 void                  gthree_animation_action_set_time                 (GthreeAnimationAction *action,
                                                                         float                  time);
+GTHREE_API
 float                 gthree_animation_action_get_time                 (GthreeAnimationAction *action);
+GTHREE_API
 gboolean              gthree_animation_action_is_running               (GthreeAnimationAction *action);
+GTHREE_API
 gboolean              gthree_animation_action_is_scheduled             (GthreeAnimationAction *action);
+GTHREE_API
 void                  gthree_animation_action_start_at                 (GthreeAnimationAction *action,
                                                                         float                  time);
+GTHREE_API
 void                  gthree_animation_action_set_loop_mode            (GthreeAnimationAction *action,
                                                                         GthreeLoopMode         loop_mode,
                                                                         int                    repetitions);
+GTHREE_API
 void                  gthree_animation_action_set_effective_weight     (GthreeAnimationAction *action,
                                                                         float                  weight);
+GTHREE_API
 float                 gthree_animation_action_get_effective_weight     (GthreeAnimationAction *action);
+GTHREE_API
 float                 gthree_animation_action_get_weight               (GthreeAnimationAction *action);
+GTHREE_API
 void                  gthree_animation_action_fade_in                  (GthreeAnimationAction *action,
                                                                         float                  duration);
+GTHREE_API
 void                  gthree_animation_action_fade_out                 (GthreeAnimationAction *action,
                                                                         float                  duration);
+GTHREE_API
 void                  gthree_animation_action_cross_fade_from          (GthreeAnimationAction *action,
                                                                         GthreeAnimationAction *fade_out_action,
                                                                         float                  duration,
                                                                         gboolean               warp);
+GTHREE_API
 void                  gthree_animation_action_cross_fade_to            (GthreeAnimationAction *action,
                                                                         GthreeAnimationAction *fade_in_action,
                                                                         float                  duration,
                                                                         gboolean               warp);
+GTHREE_API
 void                  gthree_animation_action_stop_fading              (GthreeAnimationAction *action);
+GTHREE_API
 void                  gthree_animation_action_set_effective_time_scale (GthreeAnimationAction *action,
                                                                         float                  time_scale);
+GTHREE_API
 float                 gthree_animation_action_get_effective_time_scale (GthreeAnimationAction *action);
+GTHREE_API
 float                 gthree_animation_action_get_time_scale            (GthreeAnimationAction *action);
+GTHREE_API
 void                  gthree_animation_action_set_duration             (GthreeAnimationAction *action,
                                                                         float                  duration);
+GTHREE_API
 void                  gthree_animation_action_sync_with                (GthreeAnimationAction *action,
                                                                         GthreeAnimationAction *other_action);
+GTHREE_API
 void                  gthree_animation_action_halt                     (GthreeAnimationAction *action,
                                                                         float                  duration);
+GTHREE_API
 void                  gthree_animation_action_warp                     (GthreeAnimationAction *action,
                                                                         float                  start_time_scale,
                                                                         float                  end_time_scale,
                                                                         float                  duration);
+GTHREE_API
 void                  gthree_animation_action_stop_warping             (GthreeAnimationAction *action);
+GTHREE_API
 GthreeAnimationMixer *gthree_animation_action_get_mixer                (GthreeAnimationAction *action);
+GTHREE_API
 GthreeAnimationClip * gthree_animation_action_get_clip                 (GthreeAnimationAction *action);
+GTHREE_API
 GthreeObject *        gthree_animation_action_get_root                 (GthreeAnimationAction *action);
 
 

--- a/gthree/gthreeanimationclip.h
+++ b/gthree/gthreeanimationclip.h
@@ -32,18 +32,28 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeAnimationClip, g_object_unref)
 
+GTHREE_API
 GType gthree_animation_clip_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeAnimationClip *gthree_animation_clip_new          (const char          *name,
                                                          float                duration);
+GTHREE_API
 void                 gthree_animation_clip_add_track    (GthreeAnimationClip *clip,
                                                          GthreeKeyframeTrack *track);
+GTHREE_API
 void                 gthree_animation_reset_duration    (GthreeAnimationClip *clip);
+GTHREE_API
 void                 gthree_animation_optimize          (GthreeAnimationClip *clip);
+GTHREE_API
 void                 gthree_animation_trim              (GthreeAnimationClip *clip);
+GTHREE_API
 const char *         gthree_animation_clip_get_name     (GthreeAnimationClip *clip);
+GTHREE_API
 float                gthree_animation_clip_get_duration (GthreeAnimationClip *clip);
+GTHREE_API
 int                  gthree_animation_clip_get_n_tracks (GthreeAnimationClip *clip);
+GTHREE_API
 GthreeKeyframeTrack *gthree_animation_clip_get_track    (GthreeAnimationClip *clip,
                                                          int                  i);
 

--- a/gthree/gthreeanimationmixer.h
+++ b/gthree/gthreeanimationmixer.h
@@ -35,32 +35,46 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeAnimationMixer, g_object_unref)
 
+GTHREE_API
 GType gthree_animation_mixer_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeAnimationMixer *gthree_animation_mixer_new (GthreeObject *root);
 
+GTHREE_API
 GthreeAnimationAction *gthree_animation_mixer_clip_action     (GthreeAnimationMixer *mixer,
                                                                GthreeAnimationClip  *clip,
                                                                GthreeObject         *optional_root);
+GTHREE_API
 GthreeAnimationAction *gthree_animation_mixer_existing_action (GthreeAnimationMixer *mixer,
                                                                GthreeAnimationClip  *clip,
                                                                GthreeObject         *optional_root);
+GTHREE_API
 void                   gthree_animation_mixer_stop_all_action (GthreeAnimationMixer *mixer);
+GTHREE_API
 void                   gthree_animation_mixer_update          (GthreeAnimationMixer *mixer,
                                                                float                 delta_time);
+GTHREE_API
 void                   gthree_animation_mixer_uncache_clip    (GthreeAnimationMixer *mixer,
                                                                GthreeAnimationClip  *clip);
+GTHREE_API
 void                   gthree_animation_mixer_uncache_root    (GthreeAnimationMixer *mixer,
                                                                GthreeObject         *object);
+GTHREE_API
 void                   gthree_animation_mixer_uncache_action  (GthreeAnimationMixer *mixer,
                                                                GthreeAnimationClip  *clip,
                                                                GthreeObject         *optional_root);
+GTHREE_API
 float                  gthree_animation_mixer_get_time        (GthreeAnimationMixer *mixer);
+GTHREE_API
 void                   gthree_animation_mixer_set_time        (GthreeAnimationMixer *mixer,
                                                                float                 time);
+GTHREE_API
 float                  gthree_animation_mixer_get_time_scale  (GthreeAnimationMixer *mixer);
+GTHREE_API
 void                   gthree_animation_mixer_set_time_scale  (GthreeAnimationMixer *mixer,
                                                                float                 time_scale);
+GTHREE_API
 GthreeObject *         gthree_animation_mixer_get_root        (GthreeAnimationMixer *mixer);
 
 G_END_DECLS

--- a/gthree/gthreearea.h
+++ b/gthree/gthreearea.h
@@ -27,17 +27,24 @@ typedef struct {
   GtkGLAreaClass parent_class;
 } GthreeAreaClass;
 
+GTHREE_API
 GType gthree_area_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GtkWidget *gthree_area_new (GthreeScene *scene,
                             GthreeCamera *camera);
 
+GTHREE_API
 GthreeScene *   gthree_area_get_scene    (GthreeArea   *area);
+GTHREE_API
 void            gthree_area_set_scene    (GthreeArea   *area,
                                           GthreeScene  *scene);
+GTHREE_API
 GthreeCamera *  gthree_area_get_camera   (GthreeArea   *area);
+GTHREE_API
 void            gthree_area_set_camera   (GthreeArea   *area,
                                           GthreeCamera *camera);
+GTHREE_API
 GthreeRenderer *gthree_area_get_renderer (GthreeArea   *area);
 
 G_END_DECLS

--- a/gthree/gthreeattribute.h
+++ b/gthree/gthreeattribute.h
@@ -13,71 +13,103 @@
 
 G_BEGIN_DECLS
 
+GTHREE_API
 int gthree_attribute_type_length (GthreeAttributeType type);
 
+GTHREE_API
 GthreeAttributeArray *gthree_attribute_array_new                (GthreeAttributeType   type,
                                                                  int                   count,
                                                                  int                   stride);
+GTHREE_API
 GthreeAttributeArray *gthree_attribute_array_new_from_float     (float                *data,
                                                                  int                   count,
                                                                  int                   item_size);
+GTHREE_API
 GthreeAttributeArray *gthree_attribute_array_new_from_uint16    (guint16              *data,
                                                                  int                   count,
                                                                  int                   item_size);
+GTHREE_API
 GthreeAttributeArray *gthree_attribute_array_new_from_uint32    (guint32              *data,
                                                                  int                   count,
                                                                  int                   item_size);
+GTHREE_API
 GthreeAttributeArray *gthree_attribute_array_reshape (GthreeAttributeArray *array,
                                                       guint                 index,
                                                       guint                 offset,
                                                       guint                 count,
                                                       guint                 item_size,
                                                       gboolean              share_if_possible);
+GTHREE_API
 GthreeAttributeArray *gthree_attribute_array_ref                (GthreeAttributeArray *array);
+GTHREE_API
 void                  gthree_attribute_array_unref              (GthreeAttributeArray *array);
+GTHREE_API
 GthreeAttributeType   gthree_attribute_array_get_attribute_type (GthreeAttributeArray *array);
+GTHREE_API
 int                   gthree_attribute_array_get_len            (GthreeAttributeArray *array);
+GTHREE_API
 int                   gthree_attribute_array_get_count          (GthreeAttributeArray *array);
+GTHREE_API
 int                   gthree_attribute_array_get_stride         (GthreeAttributeArray *array);
+GTHREE_API
 guint8 *              gthree_attribute_array_peek_uint8         (GthreeAttributeArray *array);
+GTHREE_API
 guint8 *              gthree_attribute_array_peek_uint8_at      (GthreeAttributeArray *array,
                                                                  int                   index,
                                                                  int                   offset);
+GTHREE_API
 gint8 *               gthree_attribute_array_peek_int8          (GthreeAttributeArray *array);
+GTHREE_API
 gint8 *               gthree_attribute_array_peek_int8_at       (GthreeAttributeArray *array,
                                                                  int                   index,
                                                                  int                   offset);
+GTHREE_API
 gint16 *              gthree_attribute_array_peek_int16         (GthreeAttributeArray *array);
+GTHREE_API
 gint16 *              gthree_attribute_array_peek_int16_at      (GthreeAttributeArray *array,
                                                                  int                   index,
                                                                  int                   offset);
+GTHREE_API
 guint16 *             gthree_attribute_array_peek_uint16        (GthreeAttributeArray *array);
+GTHREE_API
 guint16 *             gthree_attribute_array_peek_uint16_at     (GthreeAttributeArray *array,
                                                                  int                   index,
                                                                  int                   offset);
+GTHREE_API
 gint32 *              gthree_attribute_array_peek_int32         (GthreeAttributeArray *array);
+GTHREE_API
 gint32 *              gthree_attribute_array_peek_int32_at      (GthreeAttributeArray *array,
                                                                  int                   index,
                                                                  int                   offset);
+GTHREE_API
 guint32 *             gthree_attribute_array_peek_uint32        (GthreeAttributeArray *array);
+GTHREE_API
 guint32 *             gthree_attribute_array_peek_uint32_at     (GthreeAttributeArray *array,
                                                                  int                   index,
                                                                  int                   offset);
+GTHREE_API
 float *               gthree_attribute_array_peek_float         (GthreeAttributeArray *array);
+GTHREE_API
 float *               gthree_attribute_array_peek_float_at      (GthreeAttributeArray *array,
                                                                  int                   index,
                                                                  int                   offset);
+GTHREE_API
 float                 gthree_attribute_array_get_float_at       (GthreeAttributeArray *array,
                                                                  int                   index,
                                                                  int                   offset);
+GTHREE_API
 double *              gthree_attribute_array_peek_double        (GthreeAttributeArray *array);
+GTHREE_API
 double *              gthree_attribute_array_peek_double_at     (GthreeAttributeArray *array,
                                                                  int                   index,
                                                                  int                   offset);
+GTHREE_API
 graphene_point3d_t *  gthree_attribute_array_peek_point3d       (GthreeAttributeArray *array);
+GTHREE_API
 graphene_point3d_t *  gthree_attribute_array_peek_point3d_at    (GthreeAttributeArray *array,
                                                                  int                   index,
                                                                  int                   offset);
+GTHREE_API
 void                  gthree_attribute_array_copy_at            (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
@@ -86,6 +118,7 @@ void                  gthree_attribute_array_copy_at            (GthreeAttribute
                                                                  guint                 source_offset,
                                                                  guint                 n_elements,
                                                                  guint                 n_items);
+GTHREE_API
 void                  gthree_attribute_array_copy_float         (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
@@ -93,6 +126,7 @@ void                  gthree_attribute_array_copy_float         (GthreeAttribute
                                                                  guint                 source_stride,
                                                                  guint                 n_elements,
                                                                  guint                 n_items);
+GTHREE_API
 void                  gthree_attribute_array_copy_uint16        (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
@@ -100,6 +134,7 @@ void                  gthree_attribute_array_copy_uint16        (GthreeAttribute
                                                                  guint                 source_stride,
                                                                  guint                 n_elements,
                                                                  guint                 n_items);
+GTHREE_API
 void                  gthree_attribute_array_copy_uint32        (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
@@ -107,39 +142,47 @@ void                  gthree_attribute_array_copy_uint32        (GthreeAttribute
                                                                  guint                 source_stride,
                                                                  guint                 n_elements,
                                                                  guint                 n_items);
+GTHREE_API
 void                  gthree_attribute_array_set_x              (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  float                 x);
+GTHREE_API
 void                  gthree_attribute_array_set_y              (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  float                 y);
+GTHREE_API
 void                  gthree_attribute_array_set_z              (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  float                 z);
+GTHREE_API
 void                  gthree_attribute_array_set_w              (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  float                 w);
+GTHREE_API
 void                  gthree_attribute_array_set_xy             (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  float                 x,
                                                                  float                 y);
+GTHREE_API
 void                  gthree_attribute_array_set_xyz            (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  float                 x,
                                                                  float                 y,
                                                                  float                 z);
+GTHREE_API
 void                  gthree_attribute_array_get_xyz            (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  float                *x,
                                                                  float                *y,
                                                                  float                *z);
+GTHREE_API
 void                  gthree_attribute_array_set_xyzw           (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
@@ -147,6 +190,7 @@ void                  gthree_attribute_array_set_xyzw           (GthreeAttribute
                                                                  float                 y,
                                                                  float                 z,
                                                                  float                 w);
+GTHREE_API
 void                  gthree_attribute_array_get_xyzw           (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
@@ -154,75 +198,94 @@ void                  gthree_attribute_array_get_xyzw           (GthreeAttribute
                                                                  float                *y,
                                                                  float                *z,
                                                                  float                *w);
+GTHREE_API
 void                  gthree_attribute_array_set_point3d        (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  graphene_point3d_t   *point);
+GTHREE_API
 void                  gthree_attribute_array_set_vec2           (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  graphene_vec2_t      *vec2);
+GTHREE_API
 void                  gthree_attribute_array_set_vec3           (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  graphene_vec3_t      *vec3);
+GTHREE_API
 void                  gthree_attribute_array_set_vec4           (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  graphene_vec4_t      *vec4);
+GTHREE_API
 void                  gthree_attribute_array_get_vec4           (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  graphene_vec4_t      *vec4);
+GTHREE_API
 void                  gthree_attribute_array_get_matrix         (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  graphene_matrix_t    *matrix);
+GTHREE_API
 void                  gthree_attribute_array_set_rgb            (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  GdkRGBA              *color);
+GTHREE_API
 void                  gthree_attribute_array_set_rgba           (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  GdkRGBA              *color);
+GTHREE_API
 void                  gthree_attribute_array_set_uint8          (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  gint8                 value);
+GTHREE_API
 guint8                gthree_attribute_array_get_uint8          (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset);
+GTHREE_API
 void                  gthree_attribute_array_set_uint16         (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  gint16                value);
+GTHREE_API
 guint16               gthree_attribute_array_get_uint16         (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset);
+GTHREE_API
 void                  gthree_attribute_array_set_uint32         (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  guint32               value);
+GTHREE_API
 guint32               gthree_attribute_array_get_uint32         (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset);
+GTHREE_API
 void                  gthree_attribute_array_set_uint           (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  guint                 value);
+GTHREE_API
 guint                 gthree_attribute_array_get_uint           (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset);
+GTHREE_API
 void                  gthree_attribute_array_get_point3d        (GthreeAttributeArray *array,
                                                                  guint                 index,
                                                                  guint                 offset,
                                                                  graphene_point3d_t   *point);
+GTHREE_API
 void                  gthree_attribute_array_get_elements_as_float (GthreeAttributeArray *array,
                                                                     guint                 index,
                                                                     guint                 offset,
                                                                     float                *dest,
                                                                     guint                 n_elements);
+GTHREE_API
 void                  gthree_attribute_array_set_elements_from_float (GthreeAttributeArray *array,
                                                                       guint                 index,
                                                                       guint                 offset,
@@ -240,169 +303,236 @@ void                  gthree_attribute_array_set_elements_from_float (GthreeAttr
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeAttributeArray, gthree_attribute_array_unref)
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeAttribute, g_object_unref)
 
+GTHREE_API
 GType gthree_attribute_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeAttribute *gthree_attribute_new                        (const char           *name,
                                                               GthreeAttributeType   type,
                                                               int                   count,
                                                               int                   item_size,
                                                               gboolean              normalized);
+GTHREE_API
 GthreeAttribute *gthree_attribute_copy                       (const char           *name,
                                                               GthreeAttribute      *source);
+GTHREE_API
 GthreeAttribute *gthree_attribute_new_from_float             (const char           *name,
                                                               float                *data,
                                                               int                   count,
                                                               int                   item_size);
+GTHREE_API
 GthreeAttribute *gthree_attribute_new_from_uint32            (const char           *name,
                                                               guint32              *data,
                                                               int                   count,
                                                               int                   item_size);
+GTHREE_API
 GthreeAttribute *gthree_attribute_new_from_uint16            (const char           *name,
                                                               guint16              *data,
                                                               int                   count,
                                                               int                   item_size);
+GTHREE_API
 GthreeAttribute *gthree_attribute_new_with_array             (const char           *name,
                                                               GthreeAttributeArray *array,
                                                               gboolean              normalized);
+GTHREE_API
 GthreeAttribute *gthree_attribute_new_with_array_interleaved (const char           *name,
                                                               GthreeAttributeArray *array,
                                                               gboolean              normalized,
                                                               int                   item_size,
                                                               int                   item_offset,
                                                               int                   count);
+GTHREE_API
 GthreeAttribute *gthree_attribute_parse_json                 (JsonObject           *root,
                                                               const char           *name);
 
+GTHREE_API
 const char *          gthree_attribute_get_name           (GthreeAttribute      *attribute);
+GTHREE_API
 GthreeAttributeArray *gthree_attribute_get_array          (GthreeAttribute      *attribute);
+GTHREE_API
 void                  gthree_attribute_set_array          (GthreeAttribute      *attribute,
                                                            GthreeAttributeArray *array);
+GTHREE_API
 void                  gthree_attribute_set_needs_update   (GthreeAttribute      *attribute);
+GTHREE_API
 int                   gthree_attribute_get_count          (GthreeAttribute      *attribute);
+GTHREE_API
 GthreeAttributeType   gthree_attribute_get_attribute_type (GthreeAttribute      *attribute);
+GTHREE_API
 int                   gthree_attribute_get_stride         (GthreeAttribute      *attribute);
+GTHREE_API
 int                   gthree_attribute_get_item_size      (GthreeAttribute      *attribute);
+GTHREE_API
 int                   gthree_attribute_get_item_offset    (GthreeAttribute      *attribute);
+GTHREE_API
 gboolean              gthree_attribute_get_normalized     (GthreeAttribute      *attribute);
+GTHREE_API
 gboolean              gthree_attribute_get_dynamic        (GthreeAttribute      *attribute);
+GTHREE_API
 void                  gthree_attribute_set_dynamic        (GthreeAttribute      *attribute,
                                                            gboolean              dynamic);
+GTHREE_API
 void                  gthree_attribute_copy_at            (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            GthreeAttribute      *source,
                                                            guint                 source_index,
                                                            guint                 n_items);
+GTHREE_API
 void                  gthree_attribute_update             (GthreeAttribute      *attribute,
                                                            int                   buffer_type);
+GTHREE_API
 guint8 *              gthree_attribute_peek_uint8         (GthreeAttribute      *attribute);
+GTHREE_API
 guint8 *              gthree_attribute_peek_uint8_at      (GthreeAttribute      *attribute,
                                                            int                   index);
+GTHREE_API
 gint8 *               gthree_attribute_peek_int8          (GthreeAttribute      *attribute);
+GTHREE_API
 gint8 *               gthree_attribute_peek_int8_at       (GthreeAttribute      *attribute,
                                                            int                   index);
+GTHREE_API
 gint16 *              gthree_attribute_peek_int16         (GthreeAttribute      *attribute);
+GTHREE_API
 gint16 *              gthree_attribute_peek_int16_at      (GthreeAttribute      *attribute,
                                                            int                   index);
+GTHREE_API
 guint16 *             gthree_attribute_peek_uint16        (GthreeAttribute      *attribute);
+GTHREE_API
 guint16 *             gthree_attribute_peek_uint16_at     (GthreeAttribute      *attribute,
                                                            int                   index);
+GTHREE_API
 gint32 *              gthree_attribute_peek_int32         (GthreeAttribute      *attribute);
+GTHREE_API
 gint32 *              gthree_attribute_peek_int32_at      (GthreeAttribute      *attribute,
                                                            int                   index);
+GTHREE_API
 guint32 *             gthree_attribute_peek_uint32        (GthreeAttribute      *attribute);
+GTHREE_API
 guint32 *             gthree_attribute_peek_uint32_at     (GthreeAttribute      *attribute,
                                                            int                   index);
+GTHREE_API
 float *               gthree_attribute_peek_float         (GthreeAttribute      *attribute);
+GTHREE_API
 float *               gthree_attribute_peek_float_at      (GthreeAttribute      *attribute,
                                                            int                   index);
+GTHREE_API
 double *              gthree_attribute_peek_double        (GthreeAttribute      *attribute);
+GTHREE_API
 double *              gthree_attribute_peek_double_at     (GthreeAttribute      *attribute,
                                                            int                   index);
+GTHREE_API
 graphene_point3d_t *  gthree_attribute_peek_point3d       (GthreeAttribute      *attribute);
+GTHREE_API
 graphene_point3d_t *  gthree_attribute_peek_point3d_at    (GthreeAttribute      *attribute,
                                                            int                   index);
+GTHREE_API
 void                  gthree_attribute_set_x              (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            float                 x);
+GTHREE_API
 void                  gthree_attribute_set_y              (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            float                 y);
+GTHREE_API
 void                  gthree_attribute_set_z              (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            float                 z);
+GTHREE_API
 void                  gthree_attribute_set_w              (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            float                 w);
+GTHREE_API
 void                  gthree_attribute_set_xy             (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            float                 x,
                                                            float                 y);
+GTHREE_API
 void                  gthree_attribute_set_xyz            (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            float                 x,
                                                            float                 y,
                                                            float                 z);
+GTHREE_API
 void                  gthree_attribute_get_xyz            (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            float                *x,
                                                            float                *y,
                                                            float                *z);
+GTHREE_API
 void                  gthree_attribute_set_xyzw           (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            float                 x,
                                                            float                 y,
                                                            float                 z,
                                                            float                 w);
+GTHREE_API
 void                  gthree_attribute_get_xyzw           (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            float                *x,
                                                            float                *y,
                                                            float                *z,
                                                            float                *w);
+GTHREE_API
 void                  gthree_attribute_set_point3d        (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            graphene_point3d_t   *point);
+GTHREE_API
 void                  gthree_attribute_set_vec2           (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            graphene_vec2_t      *vec2);
+GTHREE_API
 void                  gthree_attribute_set_vec3           (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            graphene_vec3_t      *vec3);
+GTHREE_API
 void                  gthree_attribute_set_vec4           (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            graphene_vec4_t      *vec4);
+GTHREE_API
 void                  gthree_attribute_get_vec4           (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            graphene_vec4_t      *vec4);
+GTHREE_API
 void                  gthree_attribute_get_matrix         (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            graphene_matrix_t    *matrix);
+GTHREE_API
 void                  gthree_attribute_set_rgb            (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            GdkRGBA              *color);
+GTHREE_API
 void                  gthree_attribute_set_rgba           (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            GdkRGBA              *color);
+GTHREE_API
 void                  gthree_attribute_set_uint8          (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            gint8                 value);
+GTHREE_API
 guint8                gthree_attribute_get_uint8          (GthreeAttribute      *attribute,
                                                            guint                 index);
+GTHREE_API
 void                  gthree_attribute_set_uint16         (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            gint16                value);
+GTHREE_API
 guint16               gthree_attribute_get_uint16         (GthreeAttribute      *attribute,
                                                            guint                 index);
+GTHREE_API
 void                  gthree_attribute_set_uint32         (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            guint32               value);
+GTHREE_API
 guint32               gthree_attribute_get_uint32         (GthreeAttribute      *attribute,
                                                            guint                 index);
+GTHREE_API
 void                  gthree_attribute_set_uint           (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            guint                 value);
+GTHREE_API
 guint                 gthree_attribute_get_uint           (GthreeAttribute      *attribute,
                                                            guint                 index);
+GTHREE_API
 void                  gthree_attribute_get_point3d        (GthreeAttribute      *attribute,
                                                            guint                 index,
                                                            graphene_point3d_t   *point);
@@ -410,8 +540,11 @@ void                  gthree_attribute_get_point3d        (GthreeAttribute      
 
 
 /* These are valid when realized */
+GTHREE_API
 int gthree_attribute_get_gl_buffer            (GthreeAttribute *attribute);
+GTHREE_API
 int gthree_attribute_get_gl_type              (GthreeAttribute *attribute);
+GTHREE_API
 int gthree_attribute_get_gl_bytes_per_element (GthreeAttribute *attribute);
 
 

--- a/gthree/gthreebone.h
+++ b/gthree/gthreebone.h
@@ -28,8 +28,10 @@ typedef struct {
 
 } GthreeBoneClass;
 
+GTHREE_API
 GType gthree_bone_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeBone *gthree_bone_new (void);
 
 G_END_DECLS

--- a/gthree/gthreecamera.h
+++ b/gthree/gthreecamera.h
@@ -29,21 +29,32 @@ typedef struct {
   void (*update) (GthreeCamera *camera);
 } GthreeCameraClass;
 
+GTHREE_API
 GType gthree_camera_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 void                     gthree_camera_update_matrix            (GthreeCamera      *camera);
+GTHREE_API
 void                     gthree_camera_get_proj_screen_matrix   (GthreeCamera      *camera,
                                                                  graphene_matrix_t *res);
+GTHREE_API
 const graphene_matrix_t *gthree_camera_get_world_inverse_matrix (GthreeCamera      *camera);
+GTHREE_API
 const graphene_matrix_t *gthree_camera_get_projection_matrix    (GthreeCamera      *camera);
+GTHREE_API
 float                    gthree_camera_get_near                 (GthreeCamera      *camera);
+GTHREE_API
 void                     gthree_camera_set_near                 (GthreeCamera      *camera,
                                                                  float              near);
+GTHREE_API
 float                    gthree_camera_get_far                  (GthreeCamera      *camera);
+GTHREE_API
 void                     gthree_camera_set_far                  (GthreeCamera      *camera,
                                                                  float              far);
+GTHREE_API
 void                     gthree_camera_update                   (GthreeCamera      *camera);
 
+GTHREE_API
 void                     gthree_camera_unproject_point3d        (GthreeCamera      *camera,
                                                                  const graphene_point3d_t *pos,
                                                                  graphene_point3d_t *res);

--- a/gthree/gthreecolorkeyframetrack.h
+++ b/gthree/gthreecolorkeyframetrack.h
@@ -28,8 +28,10 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeColorKeyframeTrack, g_object_unref)
 
+GTHREE_API
 GType gthree_color_keyframe_track_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeKeyframeTrack *gthree_color_keyframe_track_new (const char *name,
                                                       GthreeAttributeArray *times,
                                                       GthreeAttributeArray *values);

--- a/gthree/gthreecubetexture.h
+++ b/gthree/gthreecubetexture.h
@@ -26,14 +26,17 @@ typedef struct {
 
 } GthreeCubeTextureClass;
 
+GTHREE_API
 GType gthree_cube_texture_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeCubeTexture *gthree_cube_texture_new (GdkPixbuf *px,
                                             GdkPixbuf *nx,
                                             GdkPixbuf *py,
                                             GdkPixbuf *ny,
                                             GdkPixbuf *pz,
                                             GdkPixbuf *nz);
+GTHREE_API
 GthreeCubeTexture *gthree_cube_texture_new_from_array (GdkPixbuf *pixbufs[6]);
 
 G_END_DECLS

--- a/gthree/gthreecubicinterpolant.h
+++ b/gthree/gthreecubicinterpolant.h
@@ -28,8 +28,10 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeCubicInterpolant, g_object_unref)
 
+GTHREE_API
 GType gthree_cubic_interpolant_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeInterpolant * gthree_cubic_interpolant_new (GthreeAttributeArray *parameter_positions,
                                                    GthreeAttributeArray *sample_values);
 

--- a/gthree/gthreedirectionallight.h
+++ b/gthree/gthreedirectionallight.h
@@ -26,13 +26,17 @@ typedef struct {
 
 } GthreeDirectionalLightClass;
 
+GTHREE_API
 GType gthree_directional_light_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeDirectionalLight *gthree_directional_light_new (const GdkRGBA *color,
                                                       float intensity);
 
+GTHREE_API
 void          gthree_directional_light_set_target    (GthreeDirectionalLight *directional,
                                                       GthreeObject           *target);
+GTHREE_API
 GthreeObject *gthree_directional_light_get_target    (GthreeDirectionalLight *directional);
 
 

--- a/gthree/gthreediscreteinterpolant.h
+++ b/gthree/gthreediscreteinterpolant.h
@@ -28,8 +28,10 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeDiscreteInterpolant, g_object_unref)
 
+GTHREE_API
 GType gthree_discrete_interpolant_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeInterpolant * gthree_discrete_interpolant_new (GthreeAttributeArray *parameter_positions,
                                                      GthreeAttributeArray *sample_values);
 

--- a/gthree/gthreeeffectcomposer.h
+++ b/gthree/gthreeeffectcomposer.h
@@ -22,18 +22,24 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeEffectComposer, g_object_unref)
 
+GTHREE_API
 GType gthree_effect_composer_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeEffectComposer *gthree_effect_composer_new  (void);
 
+GTHREE_API
 void gthree_effect_composer_add_pass     (GthreeEffectComposer *composer,
                                           GthreePass     *pass);
+GTHREE_API
 void gthree_effect_composer_render       (GthreeEffectComposer *composer,
                                           GthreeRenderer       *renderer,
                                           float                 delta_time);
+GTHREE_API
 void gthree_effect_composer_reset        (GthreeEffectComposer *composer,
                                           GthreeRenderer       *renderer,
                                           GthreeRenderTarget   *render_target);
+GTHREE_API
 void gthree_effect_composer_set_size     (GthreeEffectComposer *composer,
                                           int                   width,
                                           int                   height);

--- a/gthree/gthreegeometry.h
+++ b/gthree/gthreegeometry.h
@@ -41,58 +41,91 @@ typedef struct {
   int material_index;
 } GthreeGeometryGroup;
 
+GTHREE_API
 GthreeGeometry *gthree_geometry_new ();
 
+GTHREE_API
 GthreeGeometry *gthree_geometry_parse_json (JsonObject *object);
 
+GTHREE_API
 GType gthree_geometry_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeAttribute *        gthree_geometry_add_attribute              (GthreeGeometry          *geometry,
                                                                      const char              *name,
                                                                      GthreeAttribute         *attribute);
+GTHREE_API
 void                     gthree_geometry_remove_attribute           (GthreeGeometry          *geometry,
                                                                      const char              *name);
+GTHREE_API
 GthreeAttribute *        gthree_geometry_get_attribute              (GthreeGeometry          *geometry,
                                                                      const char              *name);
+GTHREE_API
 gboolean                 gthree_geometry_has_attribute              (GthreeGeometry          *geometry,
                                                                      const char              *name);
+GTHREE_API
 GthreeAttribute *        gthree_geometry_get_position               (GthreeGeometry          *geometry);
+GTHREE_API
 int                      gthree_geometry_get_position_count         (GthreeGeometry          *geometry);
+GTHREE_API
 int                      gthree_geometry_get_vertex_count           (GthreeGeometry          *geometry);
+GTHREE_API
 GthreeAttribute *        gthree_geometry_get_normal                 (GthreeGeometry          *geometry);
+GTHREE_API
 GthreeAttribute *        gthree_geometry_get_color                  (GthreeGeometry          *geometry);
+GTHREE_API
 GthreeAttribute *        gthree_geometry_get_uv                     (GthreeGeometry          *geometry);
+GTHREE_API
 void                     gthree_geometry_set_index                  (GthreeGeometry          *geometry,
                                                                      GthreeAttribute         *index);
+GTHREE_API
 GthreeAttribute *        gthree_geometry_get_index                  (GthreeGeometry          *geometry);
+GTHREE_API
 GthreeAttribute *        gthree_geometry_get_wireframe_index        (GthreeGeometry          *geometry);
+GTHREE_API
 void                     gthree_geometry_add_morph_attribute        (GthreeGeometry          *geometry,
                                                                     const char               *name,
                                                                     GthreeAttribute          *attribute);
+GTHREE_API
 void                     gthree_geometry_remove_morph_attributes    (GthreeGeometry          *geometry,
                                                                      const char              *name);
+GTHREE_API
 GPtrArray *              gthree_geometry_get_morph_attributes       (GthreeGeometry          *geometry,
                                                                      const char              *name);
+GTHREE_API
 GList *                  gthree_geometry_get_morph_attributes_names (GthreeGeometry          *geometry);
+GTHREE_API
 gboolean                 gthree_geometry_has_morph_attributes       (GthreeGeometry          *geometry);
+GTHREE_API
 void                     gthree_geometry_add_group                  (GthreeGeometry          *geometry,
                                                                      int                      start,
                                                                      int                      count,
                                                                      int                      material_index);
+GTHREE_API
 void                     gthree_geometry_clear_groups               (GthreeGeometry          *geometry);
+GTHREE_API
 int                      gthree_geometry_get_n_groups               (GthreeGeometry          *geometry);
+GTHREE_API
 GthreeGeometryGroup *    gthree_geometry_get_group                  (GthreeGeometry          *geometry,
                                                                      int                      index);
+GTHREE_API
 GthreeGeometryGroup *    gthree_geometry_peek_groups                (GthreeGeometry          *geometry);
+GTHREE_API
 int                      gthree_geometry_get_draw_range_start       (GthreeGeometry          *geometry);
+GTHREE_API
 int                      gthree_geometry_get_draw_range_count       (GthreeGeometry          *geometry);
+GTHREE_API
 void                     gthree_geometry_set_draw_range             (GthreeGeometry          *geometry,
                                                                      int                      start,
                                                                      int                      count);
+GTHREE_API
 const graphene_sphere_t *gthree_geometry_get_bounding_sphere        (GthreeGeometry          *geometry);
+GTHREE_API
 void                     gthree_geometry_set_bounding_sphere        (GthreeGeometry          *geometry,
                                                                      const graphene_sphere_t *sphere);
+GTHREE_API
 void                     gthree_geometry_compute_vertex_normals     (GthreeGeometry          *geometry);
+GTHREE_API
 void                     gthree_geometry_normalize_normals          (GthreeGeometry          *geometry);
 
 

--- a/gthree/gthreegroup.h
+++ b/gthree/gthreegroup.h
@@ -28,8 +28,10 @@ typedef struct {
 
 } GthreeGroupClass;
 
+GTHREE_API
 GType gthree_group_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeGroup *gthree_group_new (void);
 
 G_END_DECLS

--- a/gthree/gthreeinterpolant.h
+++ b/gthree/gthreeinterpolant.h
@@ -21,6 +21,7 @@ G_BEGIN_DECLS
 
 typedef struct _GthreeInterpolantSettings GthreeInterpolantSettings;
 
+GTHREE_API
 GType gthree_interpolant_settings_get_type (void) G_GNUC_CONST;
 
 typedef struct {
@@ -38,26 +39,42 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeInterpolant, g_object_unref)
 
+GTHREE_API
 GType gthree_interpolant_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 int                        gthree_interpolant_get_n_positions         (GthreeInterpolant *interpolant);
+GTHREE_API
 int                        gthree_interpolant_get_sample_size         (GthreeInterpolant *interpolant);
+GTHREE_API
 GthreeAttributeType        gthree_interpolant_get_sample_type         (GthreeInterpolant *interpolant);
+GTHREE_API
 GthreeAttributeArray *     gthree_interpolant_get_parameter_positions (GthreeInterpolant *interpolant);
+GTHREE_API
 GthreeAttributeArray *     gthree_interpolant_get_sample_values       (GthreeInterpolant *interpolant);
+GTHREE_API
 GthreeAttributeArray *     gthree_interpolant_evaluate                (GthreeInterpolant *interpolant,
                                                                        float              t);
+GTHREE_API
 GthreeEndingMode           gthree_interpolant_get_start_ending_mode   (GthreeInterpolant *interpolant);
+GTHREE_API
 GthreeEndingMode           gthree_interpolant_get_end_ending_mode     (GthreeInterpolant *interpolant);
+GTHREE_API
 GthreeInterpolantSettings *gthree_interpolant_get_settings            (GthreeInterpolant *interpolant);
+GTHREE_API
 void                       gthree_interpolant_set_settings            (GthreeInterpolant *interpolant,
                                                                        GthreeInterpolantSettings *settings);
 
+GTHREE_API
 GthreeInterpolantSettings *gthree_interpolant_settings_new (void);
+GTHREE_API
 GthreeEndingMode      gthree_interpolant_settings_get_start_ending_mode   (GthreeInterpolantSettings *settings);
+GTHREE_API
 void                  gthree_interpolant_settings_set_start_ending_mode   (GthreeInterpolantSettings *settings,
                                                                            GthreeEndingMode   mode);
+GTHREE_API
 GthreeEndingMode      gthree_interpolant_settings_get_end_ending_mode     (GthreeInterpolantSettings *settings);
+GTHREE_API
 void                  gthree_interpolant_settings_set_end_ending_mode     (GthreeInterpolantSettings *settings,
                                                                            GthreeEndingMode   mode);
 

--- a/gthree/gthreekeyframetrack.h
+++ b/gthree/gthreekeyframetrack.h
@@ -39,20 +39,32 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeKeyframeTrack, g_object_unref)
 
+GTHREE_API
 GType gthree_keyframe_track_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 const char *          gthree_keyframe_track_get_name           (GthreeKeyframeTrack     *track);
+GTHREE_API
 float                 gthree_keyframe_track_get_end_time       (GthreeKeyframeTrack     *track);
+GTHREE_API
 GthreeAttributeArray *gthree_keyframe_track_get_times          (GthreeKeyframeTrack     *track);
+GTHREE_API
 GthreeValueType       gthree_keyframe_track_get_value_type     (GthreeKeyframeTrack     *track);
+GTHREE_API
 int                   gthree_keyframe_track_get_value_size     (GthreeKeyframeTrack     *track);
+GTHREE_API
 GthreeAttributeArray *gthree_keyframe_track_get_values         (GthreeKeyframeTrack     *track);
+GTHREE_API
 GthreeInterpolant *   gthree_keyframe_track_create_interpolant (GthreeKeyframeTrack     *track);
+GTHREE_API
 void                  gthree_keyframe_track_optimize           (GthreeKeyframeTrack     *track);
+GTHREE_API
 void                  gthree_keyframe_track_scale              (GthreeKeyframeTrack     *track,
                                                                 float                    time_scale);
+GTHREE_API
 void                  gthree_keyframe_track_set_interpolation  (GthreeKeyframeTrack     *track,
                                                                 GthreeInterpolationMode  interpolation);
+GTHREE_API
 void                  gthree_keyframe_track_trim               (GthreeKeyframeTrack     *track,
                                                                 float                    start_time,
                                                                 float                    end_time);

--- a/gthree/gthreelight.h
+++ b/gthree/gthreelight.h
@@ -33,14 +33,20 @@ typedef struct {
                           GthreeLightSetup *light_setup);
 } GthreeLightClass;
 
+GTHREE_API
 GType gthree_light_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeLight *gthree_light_new (void);
 
+GTHREE_API
 const GdkRGBA *gthree_light_get_color          (GthreeLight   *light);
+GTHREE_API
 void           gthree_light_set_color          (GthreeLight   *light,
                                                 const GdkRGBA *color);
+GTHREE_API
 float          gthree_light_get_intensity      (GthreeLight   *light);
+GTHREE_API
 void           gthree_light_set_intensity      (GthreeLight   *light,
                                                 float          intensity);
 

--- a/gthree/gthreelinearinterpolant.h
+++ b/gthree/gthreelinearinterpolant.h
@@ -28,8 +28,10 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeLinearInterpolant, g_object_unref)
 
+GTHREE_API
 GType gthree_linear_interpolant_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeInterpolant * gthree_linear_interpolant_new (GthreeAttributeArray *parameter_positions,
                                                    GthreeAttributeArray *sample_values);
 

--- a/gthree/gthreelinebasicmaterial.h
+++ b/gthree/gthreelinebasicmaterial.h
@@ -27,14 +27,20 @@ typedef struct {
 
 } GthreeLineBasicMaterialClass;
 
+GTHREE_API
 GType gthree_line_basic_material_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeLineBasicMaterial *gthree_line_basic_material_new ();
 
+GTHREE_API
 const GdkRGBA *gthree_line_basic_material_get_color      (GthreeLineBasicMaterial *line_basic);
+GTHREE_API
 void           gthree_line_basic_material_set_color      (GthreeLineBasicMaterial *line_basic,
                                                           const GdkRGBA           *color);
+GTHREE_API
 float          gthree_line_basic_material_get_line_width (GthreeLineBasicMaterial *line_basic);
+GTHREE_API
 void           gthree_line_basic_material_set_line_width (GthreeLineBasicMaterial *line_basic,
                                                           float                    line_width);
 

--- a/gthree/gthreelinesegments.h
+++ b/gthree/gthreelinesegments.h
@@ -27,8 +27,10 @@ typedef struct {
 
 } GthreeLineSegmentsClass;
 
+GTHREE_API
 GType gthree_line_segments_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeLineSegments *gthree_line_segments_new (GthreeGeometry *geometry,
                                               GthreeMaterial *material);
 

--- a/gthree/gthreeloader.h
+++ b/gthree/gthreeloader.h
@@ -39,21 +39,31 @@ typedef enum {
 #define GTHREE_LOADER_ERROR               (gthree_loader_error_quark ())
 
 
+GTHREE_API
 GQuark gthree_loader_error_quark (void);
+GTHREE_API
 GType gthree_loader_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 int                  gthree_loader_get_n_scenes     (GthreeLoader *loader);
+GTHREE_API
 GthreeScene *        gthree_loader_get_scene        (GthreeLoader *loader,
                                                      int           index);
+GTHREE_API
 int                  gthree_loader_get_n_materials  (GthreeLoader *loader);
+GTHREE_API
 GthreeMaterial *     gthree_loader_get_material     (GthreeLoader *loader,
                                                      int           index);
+GTHREE_API
 int                  gthree_loader_get_n_animations (GthreeLoader *loader);
+GTHREE_API
 GthreeAnimationClip *gthree_loader_get_animation    (GthreeLoader *loader,
                                                      int           index);
 
+GTHREE_API
 GthreeLoader *gthree_loader_parse_gltf (GBytes *data, GFile *base_path, GError **error);
 
+GTHREE_API
 GthreeGeometry *gthree_load_geometry_from_json (const char *data, GError **error);
 G_END_DECLS
 

--- a/gthree/gthreematerial.h
+++ b/gthree/gthreematerial.h
@@ -50,64 +50,95 @@ typedef struct {
 
 } GthreeMaterialClass;
 
+GTHREE_API
 GType gthree_material_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeMaterial *  gthree_material_clone                    (GthreeMaterial          *material);
 
+GTHREE_API
 gboolean          gthree_material_get_is_visible           (GthreeMaterial          *material);
+GTHREE_API
 void              gthree_material_set_is_visible           (GthreeMaterial          *material,
                                                             gboolean                 is_visible);
+GTHREE_API
 gboolean          gthree_material_get_is_transparent       (GthreeMaterial          *material);
+GTHREE_API
 void              gthree_material_set_is_transparent       (GthreeMaterial          *material,
                                                             gboolean                 is_transparent);
+GTHREE_API
 float             gthree_material_get_opacity              (GthreeMaterial          *material);
+GTHREE_API
 void              gthree_material_set_opacity              (GthreeMaterial          *material,
                                                             float                    opacity);
+GTHREE_API
 GthreeBlendMode   gthree_material_get_blend_mode           (GthreeMaterial          *material,
                                                             guint                   *equation,
                                                             guint                   *src_factor,
                                                             guint                   *dst_factor);
+GTHREE_API
 void              gthree_material_set_blend_mode           (GthreeMaterial          *material,
                                                             GthreeBlendMode          mode,
                                                             guint                    equation,
                                                             guint                    src_factor,
                                                             guint                    dst_factor);
+GTHREE_API
 gboolean          gthree_material_get_polygon_offset       (GthreeMaterial          *material,
                                                             float                   *factor,
                                                             float                   *units);
+GTHREE_API
 void              gthree_material_set_polygon_offset       (GthreeMaterial          *material,
                                                             gboolean                 polygon_offset,
                                                             float                    factor,
                                                             float                    units);
+GTHREE_API
 gboolean          gthree_material_get_depth_test           (GthreeMaterial          *material);
+GTHREE_API
 void              gthree_material_set_depth_test           (GthreeMaterial          *material,
                                                             gboolean                 depth_test);
+GTHREE_API
 gboolean          gthree_material_get_depth_write          (GthreeMaterial          *material);
+GTHREE_API
 void              gthree_material_set_depth_write          (GthreeMaterial          *material,
                                                             gboolean                 depth_write);
+GTHREE_API
 float             gthree_material_get_alpha_test           (GthreeMaterial          *material);
+GTHREE_API
 void              gthree_material_set_alpha_test           (GthreeMaterial          *material,
                                                             float                    alpha_test);
+GTHREE_API
 GthreeSide        gthree_material_get_side                 (GthreeMaterial          *material);
+GTHREE_API
 void              gthree_material_set_side                 (GthreeMaterial          *material,
                                                             GthreeSide               side);
+GTHREE_API
 void              gthree_material_set_vertex_colors        (GthreeMaterial          *material,
                                                             gboolean                 vertex_colors);
+GTHREE_API
 gboolean          gthree_material_get_vertex_colors        (GthreeMaterial         *material);
+GTHREE_API
 GthreeShader *    gthree_material_get_shader               (GthreeMaterial          *material);
+GTHREE_API
 void              gthree_material_set_params               (GthreeMaterial          *material,
                                                             GthreeProgramParameters *params);
+GTHREE_API
 void              gthree_material_set_uniforms             (GthreeMaterial          *material,
                                                             GthreeUniforms          *uniforms,
                                                             GthreeCamera            *camera);
+GTHREE_API
 void              gthree_material_load_default_attribute   (GthreeMaterial          *material,
                                                             int                      attribute_location,
                                                             GQuark                   attribute);
+GTHREE_API
 gboolean          gthree_material_get_needs_update         (GthreeMaterial          *material);
+GTHREE_API
 void              gthree_material_set_needs_update         (GthreeMaterial          *material,
                                                             gboolean                 needs_update);
+GTHREE_API
 gboolean          gthree_material_needs_camera_pos         (GthreeMaterial          *material);
+GTHREE_API
 gboolean          gthree_material_needs_view_matrix        (GthreeMaterial          *material);
+GTHREE_API
 gboolean          gthree_material_needs_lights             (GthreeMaterial          *material);
 
 G_END_DECLS

--- a/gthree/gthreemesh.h
+++ b/gthree/gthreemesh.h
@@ -29,28 +29,42 @@ typedef struct {
 
 } GthreeMeshClass;
 
+GTHREE_API
 GType gthree_mesh_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeMesh *gthree_mesh_new (GthreeGeometry *geometry,
                              GthreeMaterial *material);
 
+GTHREE_API
 GthreeMaterial *gthree_mesh_get_material         (GthreeMesh     *mesh,
                                                   int             index);
+GTHREE_API
 int             gthree_mesh_get_n_materials      (GthreeMesh     *mesh);
+GTHREE_API
 void            gthree_mesh_set_materials        (GthreeMesh     *mesh,
                                                   GPtrArray      *materials);
+GTHREE_API
 void            gthree_mesh_set_material         (GthreeMesh     *mesh,
                                                   int             index,
                                                   GthreeMaterial *material);
+GTHREE_API
 void            gthree_mesh_add_material         (GthreeMesh     *mesh,
                                                   GthreeMaterial *material);
+GTHREE_API
 GthreeGeometry *gthree_mesh_get_geometry         (GthreeMesh     *mesh);
+GTHREE_API
 GthreeDrawMode  gthree_mesh_get_draw_mode        (GthreeMesh     *mesh);
+GTHREE_API
 void            gthree_mesh_set_draw_mode        (GthreeMesh     *mesh,
                                                   GthreeDrawMode  mode);
+GTHREE_API
 void            gthree_mesh_update_morph_targets (GthreeMesh     *mesh);
+GTHREE_API
 gboolean        gthree_mesh_has_morph_targets    (GthreeMesh     *mesh);
+GTHREE_API
 GArray *        gthree_mesh_get_morph_targets    (GthreeMesh     *mesh);
+GTHREE_API
 void            gthree_mesh_set_morph_targets    (GthreeMesh     *mesh,
                                                   GArray         *morph_targets);
 

--- a/gthree/gthreemeshbasicmaterial.h
+++ b/gthree/gthreemeshbasicmaterial.h
@@ -27,25 +27,39 @@ typedef struct {
 
 } GthreeMeshBasicMaterialClass;
 
+GTHREE_API
 GthreeMeshBasicMaterial *gthree_mesh_basic_material_new ();
+GTHREE_API
 GType gthree_mesh_basic_material_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 const GdkRGBA *   gthree_mesh_basic_material_get_color            (GthreeMeshBasicMaterial *basic);
+GTHREE_API
 void              gthree_mesh_basic_material_set_color            (GthreeMeshBasicMaterial *basic,
                                                                    const GdkRGBA           *color);
+GTHREE_API
 void              gthree_mesh_basic_material_set_map              (GthreeMeshBasicMaterial *basic,
                                                                    GthreeTexture           *texture);
+GTHREE_API
 GthreeTexture  *  gthree_mesh_basic_material_get_map              (GthreeMeshBasicMaterial *basic);
+GTHREE_API
 void              gthree_mesh_basic_material_set_env_map          (GthreeMeshBasicMaterial *basic,
                                                                    GthreeTexture           *texture);
+GTHREE_API
 GthreeTexture  *  gthree_mesh_basic_material_get_env_map          (GthreeMeshBasicMaterial *basic);
+GTHREE_API
 float             gthree_mesh_basic_material_get_refraction_ratio (GthreeMeshBasicMaterial *basic);
+GTHREE_API
 void              gthree_mesh_basic_material_set_refraction_ratio (GthreeMeshBasicMaterial *basic,
                                                                    float                    ratio);
+GTHREE_API
 float             gthree_mesh_basic_material_get_reflectivity     (GthreeMeshBasicMaterial *basic);
+GTHREE_API
 void              gthree_mesh_basic_material_set_reflectivity     (GthreeMeshBasicMaterial *basic,
                                                                    float                    reflectivity);
+GTHREE_API
 GthreeOperation   gthree_mesh_basic_material_get_combine          (GthreeMeshBasicMaterial *basic);
+GTHREE_API
 void              gthree_mesh_basic_material_set_combine          (GthreeMeshBasicMaterial *basic,
                                                                    GthreeOperation          combine);
 

--- a/gthree/gthreemeshdepthmaterial.h
+++ b/gthree/gthreemeshdepthmaterial.h
@@ -26,10 +26,14 @@ typedef struct {
 
 } GthreeMeshDepthMaterialClass;
 
+GTHREE_API
 GthreeMeshDepthMaterial *gthree_mesh_depth_material_new ();
+GTHREE_API
 GType gthree_mesh_depth_material_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeShadingType gthree_mesh_depth_material_get_shading_type (GthreeMeshDepthMaterial *depth);
+GTHREE_API
 void              gthree_mesh_depth_material_set_shading_type (GthreeMeshDepthMaterial *depth,
                                                                GthreeShadingType        shading_type);
 

--- a/gthree/gthreemeshlambertmaterial.h
+++ b/gthree/gthreemeshlambertmaterial.h
@@ -27,29 +27,45 @@ typedef struct {
 
 } GthreeMeshLambertMaterialClass;
 
+GTHREE_API
 GthreeMeshLambertMaterial *gthree_mesh_lambert_material_new ();
+GTHREE_API
 GType gthree_mesh_lambert_material_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 const GdkRGBA * gthree_mesh_lambert_material_get_emissive_color   (GthreeMeshLambertMaterial *lambert);
+GTHREE_API
 void            gthree_mesh_lambert_material_set_emissive_color   (GthreeMeshLambertMaterial *lambert,
                                                                    const GdkRGBA             *color);
+GTHREE_API
 const GdkRGBA * gthree_mesh_lambert_material_get_color            (GthreeMeshLambertMaterial *lambert);
+GTHREE_API
 void            gthree_mesh_lambert_material_set_color            (GthreeMeshLambertMaterial *lambert,
                                                                    const GdkRGBA             *color);
+GTHREE_API
 float           gthree_mesh_lambert_material_get_refraction_ratio (GthreeMeshLambertMaterial *lambert);
+GTHREE_API
 void            gthree_mesh_lambert_material_set_refraction_ratio (GthreeMeshLambertMaterial *lambert,
                                                                    float                      ratio);
+GTHREE_API
 float           gthree_mesh_lambert_material_get_reflectivity     (GthreeMeshLambertMaterial *lambert);
+GTHREE_API
 void            gthree_mesh_lambert_material_set_reflectivity     (GthreeMeshLambertMaterial *lambert,
                                                                    float                      reflectivity);
+GTHREE_API
 void            gthree_mesh_lambert_material_set_map              (GthreeMeshLambertMaterial *lambert,
                                                                    GthreeTexture             *texture);
+GTHREE_API
 GthreeTexture * gthree_mesh_lambert_material_get_map              (GthreeMeshLambertMaterial *lambert);
+GTHREE_API
 void            gthree_mesh_lambert_material_set_env_map          (GthreeMeshLambertMaterial *lambert,
                                                                    GthreeTexture             *texture);
+GTHREE_API
 GthreeTexture * gthree_mesh_lambert_material_get_env_map          (GthreeMeshLambertMaterial *lambert);
+GTHREE_API
 void            gthree_mesh_lambert_material_set_combine          (GthreeMeshLambertMaterial *lambert,
                                                                    GthreeOperation            combine);
+GTHREE_API
 GthreeOperation gthree_mesh_lambert_material_get_combine          (GthreeMeshLambertMaterial *lambert);
 
 G_END_DECLS

--- a/gthree/gthreemeshmaterial.h
+++ b/gthree/gthreemeshmaterial.h
@@ -27,21 +27,32 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeMeshMaterial, g_object_unref)
 
+GTHREE_API
 GType gthree_mesh_material_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 gboolean gthree_mesh_material_get_is_wireframe         (GthreeMeshMaterial *material);
+GTHREE_API
 void     gthree_mesh_material_set_is_wireframe         (GthreeMeshMaterial *material,
                                                         gboolean            is_wireframe);
+GTHREE_API
 float    gthree_mesh_material_get_wireframe_line_width (GthreeMeshMaterial *material);
+GTHREE_API
 void     gthree_mesh_material_set_wireframe_line_width (GthreeMeshMaterial *material,
                                                         float               line_width);
+GTHREE_API
 gboolean gthree_mesh_material_get_skinning             (GthreeMeshMaterial *material);
+GTHREE_API
 void     gthree_mesh_material_set_skinning             (GthreeMeshMaterial *material,
                                                         gboolean            value);
+GTHREE_API
 gboolean gthree_mesh_material_get_morph_targets        (GthreeMeshMaterial *material);
+GTHREE_API
 void     gthree_mesh_material_set_morph_targets        (GthreeMeshMaterial *material,
                                                         gboolean            value);
+GTHREE_API
 gboolean gthree_mesh_material_get_morph_normals        (GthreeMeshMaterial *material);
+GTHREE_API
 void     gthree_mesh_material_set_morph_normals        (GthreeMeshMaterial *material,
                                                         gboolean            value);
 

--- a/gthree/gthreemeshnormalmaterial.h
+++ b/gthree/gthreemeshnormalmaterial.h
@@ -26,11 +26,15 @@ typedef struct {
 
 } GthreeMeshNormalMaterialClass;
 
+GTHREE_API
 GType gthree_mesh_normal_material_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeMeshNormalMaterial *gthree_mesh_normal_material_new ();
 
+GTHREE_API
 GthreeShadingType gthree_mesh_normal_material_get_shading_type (GthreeMeshNormalMaterial *normal);
+GTHREE_API
 void              gthree_mesh_normal_material_set_shading_type (GthreeMeshNormalMaterial *normal,
                                                                 GthreeShadingType         shading_type);
 

--- a/gthree/gthreemeshphongmaterial.h
+++ b/gthree/gthreemeshphongmaterial.h
@@ -27,37 +27,59 @@ typedef struct {
 
 } GthreeMeshPhongMaterialClass;
 
+GTHREE_API
 GthreeMeshPhongMaterial *gthree_mesh_phong_material_new ();
+GTHREE_API
 GType gthree_mesh_phong_material_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 const GdkRGBA *   gthree_mesh_phong_material_get_color            (GthreeMeshPhongMaterial *phong);
+GTHREE_API
 void              gthree_mesh_phong_material_set_color            (GthreeMeshPhongMaterial *phong,
                                                                    const GdkRGBA           *color);
+GTHREE_API
 const GdkRGBA *   gthree_mesh_phong_material_get_emissive_color   (GthreeMeshPhongMaterial *phong);
+GTHREE_API
 void              gthree_mesh_phong_material_set_emissive_color   (GthreeMeshPhongMaterial *phong,
                                                                    const GdkRGBA           *color);
+GTHREE_API
 const GdkRGBA *   gthree_mesh_phong_material_get_specular_color   (GthreeMeshPhongMaterial *phong);
+GTHREE_API
 void              gthree_mesh_phong_material_set_specular_color   (GthreeMeshPhongMaterial *phong,
                                                                    const GdkRGBA           *color);
+GTHREE_API
 float             gthree_mesh_phong_material_get_shininess        (GthreeMeshPhongMaterial *phong);
+GTHREE_API
 void              gthree_mesh_phong_material_set_shininess        (GthreeMeshPhongMaterial *phong,
                                                                    float                    shininess);
+GTHREE_API
 void              gthree_mesh_phong_material_set_map              (GthreeMeshPhongMaterial *phong,
                                                                    GthreeTexture           *texture);
+GTHREE_API
 GthreeTexture *   gthree_mesh_phong_material_get_map              (GthreeMeshPhongMaterial *phong);
+GTHREE_API
 void              gthree_mesh_phong_material_set_env_map          (GthreeMeshPhongMaterial *phong,
                                                                    GthreeTexture           *texture);
+GTHREE_API
 GthreeTexture *   gthree_mesh_phong_material_get_env_map          (GthreeMeshPhongMaterial *phong);
+GTHREE_API
 float             gthree_mesh_phong_material_get_refraction_ratio (GthreeMeshPhongMaterial *phong);
+GTHREE_API
 void              gthree_mesh_phong_material_set_refraction_ratio (GthreeMeshPhongMaterial *phong,
                                                                    float                    ratio);
+GTHREE_API
 float             gthree_mesh_phong_material_get_reflectivity     (GthreeMeshPhongMaterial *phong);
+GTHREE_API
 void              gthree_mesh_phong_material_set_reflectivity     (GthreeMeshPhongMaterial *phong,
                                                                    float                    reflectivity);
+GTHREE_API
 void              gthree_mesh_phong_material_set_combine          (GthreeMeshPhongMaterial *phong,
                                                                    GthreeOperation          combine);
+GTHREE_API
 GthreeOperation   gthree_mesh_phong_material_get_combine          (GthreeMeshPhongMaterial *phong);
+GTHREE_API
 gboolean          gthree_mesh_phong_material_get_flat_shading     (GthreeMeshPhongMaterial *phong);
+GTHREE_API
 void              gthree_mesh_phong_material_set_flat_shading     (GthreeMeshPhongMaterial *phong,
                                                                    gboolean                 flat_shading);
 

--- a/gthree/gthreemeshstandardmaterial.h
+++ b/gthree/gthreemeshstandardmaterial.h
@@ -29,82 +29,134 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeMeshStandardMaterial, g_object_unref)
 
+GTHREE_API
 GthreeMeshStandardMaterial *gthree_mesh_standard_material_new ();
+GTHREE_API
 GType gthree_mesh_standard_material_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 const GdkRGBA *        gthree_mesh_standard_material_get_color               (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_color               (GthreeMeshStandardMaterial *standard,
                                                                               const GdkRGBA              *color);
+GTHREE_API
 const GdkRGBA *        gthree_mesh_standard_material_get_emissive_color      (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_emissive_color      (GthreeMeshStandardMaterial *standard,
                                                                               const GdkRGBA              *color);
+GTHREE_API
 GthreeTexture *        gthree_mesh_standard_material_get_emissive_map        (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_emissive_map        (GthreeMeshStandardMaterial *standard,
                                                                               GthreeTexture              *texture);
+GTHREE_API
 float                  gthree_mesh_standard_material_get_emissive_intensity  (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_emissive_intensity  (GthreeMeshStandardMaterial *standard,
                                                                              float                       value);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_map                 (GthreeMeshStandardMaterial *standard,
                                                                               GthreeTexture              *texture);
+GTHREE_API
 GthreeTexture *        gthree_mesh_standard_material_get_map                 (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_env_map             (GthreeMeshStandardMaterial *standard,
                                                                               GthreeTexture              *texture);
+GTHREE_API
 GthreeTexture *        gthree_mesh_standard_material_get_env_map             (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 float                  gthree_mesh_standard_material_get_env_map_intensity   (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_env_map_intensity   (GthreeMeshStandardMaterial *standard,
                                                                               float                       value);
+GTHREE_API
 float                  gthree_mesh_standard_material_get_refraction_ratio    (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_refraction_ratio    (GthreeMeshStandardMaterial *standard,
                                                                               float                       ratio);
+GTHREE_API
 float                  gthree_mesh_standard_material_get_roughness           (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_roughness           (GthreeMeshStandardMaterial *standard,
                                                                               float                       ratio);
+GTHREE_API
 float                  gthree_mesh_standard_material_get_metalness           (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_metalness           (GthreeMeshStandardMaterial *standard,
                                                                               float                       value);
+GTHREE_API
 GthreeTexture*         gthree_mesh_standard_material_get_light_map           (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_light_map           (GthreeMeshStandardMaterial *standard,
                                                                               GthreeTexture              *texture);
+GTHREE_API
 float                  gthree_mesh_standard_material_get_light_map_intensity (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_light_map_intensity (GthreeMeshStandardMaterial *standard,
                                                                               float                       value);
+GTHREE_API
 GthreeTexture*         gthree_mesh_standard_material_get_ao_map              (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_ao_map              (GthreeMeshStandardMaterial *standard,
                                                                               GthreeTexture              *texture);
+GTHREE_API
 float                  gthree_mesh_standard_material_get_ao_map_intensity    (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_ao_map_intensity    (GthreeMeshStandardMaterial *standard,
                                                                               float                       value);
+GTHREE_API
 GthreeTexture*         gthree_mesh_standard_material_get_bump_map            (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_bump_map            (GthreeMeshStandardMaterial *standard,
                                                                               GthreeTexture              *texture);
+GTHREE_API
 float                  gthree_mesh_standard_material_get_bump_scale          (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_bump_scale          (GthreeMeshStandardMaterial *standard,
                                                                               float                       value);
+GTHREE_API
 GthreeTexture*         gthree_mesh_standard_material_get_normal_map          (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_normal_map          (GthreeMeshStandardMaterial *standard,
                                                                               GthreeTexture              *texture);
+GTHREE_API
 GthreeNormalMapType    gthree_mesh_standard_material_get_normal_map_type     (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_normal_map_type     (GthreeMeshStandardMaterial *standard,
                                                                               GthreeNormalMapType         type);
+GTHREE_API
 const graphene_vec2_t *gthree_mesh_standard_material_get_normal_map_scale    (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_normal_map_scale    (GthreeMeshStandardMaterial *standard,
                                                                               graphene_vec2_t            *scale);
+GTHREE_API
 GthreeTexture*         gthree_mesh_standard_material_get_displacement_map    (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_displacement_map    (GthreeMeshStandardMaterial *standard,
                                                                               GthreeTexture              *texture);
+GTHREE_API
 float                  gthree_mesh_standard_material_get_displacement_scale  (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_displacement_scale  (GthreeMeshStandardMaterial *standard,
                                                                               float                       value);
+GTHREE_API
 float                  gthree_mesh_standard_material_get_displacement_bias   (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_displacement_bias   (GthreeMeshStandardMaterial *standard,
                                                                               float                       value);
+GTHREE_API
 GthreeTexture*         gthree_mesh_standard_material_get_roughness_map       (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_roughness_map       (GthreeMeshStandardMaterial *standard,
                                                                               GthreeTexture              *texture);
+GTHREE_API
 GthreeTexture*         gthree_mesh_standard_material_get_metalness_map       (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_metalness_map       (GthreeMeshStandardMaterial *standard,
                                                                               GthreeTexture              *texture);
+GTHREE_API
 GthreeTexture*         gthree_mesh_standard_material_get_alpha_map           (GthreeMeshStandardMaterial *standard);
+GTHREE_API
 void                   gthree_mesh_standard_material_set_alpha_map           (GthreeMeshStandardMaterial *standard,
                                                                               GthreeTexture              *texture);
 

--- a/gthree/gthreenumberkeyframetrack.h
+++ b/gthree/gthreenumberkeyframetrack.h
@@ -28,8 +28,10 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeNumberKeyframeTrack, g_object_unref)
 
+GTHREE_API
 GType gthree_number_keyframe_track_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeKeyframeTrack *gthree_number_keyframe_track_new (const char *name,
                                                        GthreeAttributeArray *times,
                                                        GthreeAttributeArray *values);

--- a/gthree/gthreeobject.h
+++ b/gthree/gthreeobject.h
@@ -47,8 +47,10 @@ typedef struct {
                                   GthreeRenderList      *list);
 } GthreeObjectClass;
 
+GTHREE_API
 GType gthree_object_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeObject *gthree_object_new ();
 
 typedef void (*GthreeBeforeRenderCallback) (GthreeObject                *object,
@@ -57,69 +59,111 @@ typedef void (*GthreeBeforeRenderCallback) (GthreeObject                *object,
 
 
 
+GTHREE_API
 const char *                 gthree_object_get_name                     (GthreeObject                *object);
+GTHREE_API
 void                         gthree_object_set_name                     (GthreeObject                *object,
                                                                          const char                  *name);
+GTHREE_API
 const char *                 gthree_object_get_uuid                     (GthreeObject                *object);
+GTHREE_API
 void                         gthree_object_set_uuid                     (GthreeObject                *object,
                                                                          const char                  *uuid);
+GTHREE_API
 const graphene_matrix_t *    gthree_object_get_world_matrix             (GthreeObject                *object);
+GTHREE_API
 void                         gthree_object_set_world_matrix             (GthreeObject                *object,
                                                                          const graphene_matrix_t     *matrix);
+GTHREE_API
 void                         gthree_object_set_matrix_auto_update       (GthreeObject                *object,
                                                                          gboolean                     auto_update);
+GTHREE_API
 void                         gthree_object_update_matrix_world          (GthreeObject                *object,
                                                                          gboolean                     force);
+GTHREE_API
 void                         gthree_object_update_matrix                (GthreeObject                *object);
+GTHREE_API
 void                         gthree_object_update_matrix_view           (GthreeObject                *object,
                                                                          const graphene_matrix_t     *camera_matrix);
+GTHREE_API
 void                         gthree_object_look_at                      (GthreeObject                *object,
                                                                          graphene_point3d_t          *pos);
+GTHREE_API
 const graphene_matrix_t *    gthree_object_get_matrix                   (GthreeObject                *object);
+GTHREE_API
 void                         gthree_object_set_matrix                   (GthreeObject                *object,
                                                                          const graphene_matrix_t     *matrix);
+GTHREE_API
 void                         gthree_object_set_position                 (GthreeObject                *object,
                                                                          const graphene_point3d_t    *pos);
+GTHREE_API
 const graphene_vec3_t *      gthree_object_get_position                 (GthreeObject                *object);
+GTHREE_API
 void                         gthree_object_set_scale                    (GthreeObject                *object,
                                                                          const graphene_point3d_t    *scale);
+GTHREE_API
 const graphene_vec3_t *      gthree_object_get_scale                    (GthreeObject                *object);
+GTHREE_API
 void                         gthree_object_set_quaternion               (GthreeObject                *object,
                                                                          const graphene_quaternion_t *q);
+GTHREE_API
 const graphene_quaternion_t *gthree_object_get_quaternion               (GthreeObject                *object);
+GTHREE_API
 void                         gthree_object_set_rotation                 (GthreeObject                *object,
                                                                          const graphene_euler_t      *rot);
+GTHREE_API
 const graphene_euler_t *     gthree_object_get_rotation                 (GthreeObject                *object);
+GTHREE_API
 gboolean                     gthree_object_has_attribute_data           (GthreeObject                *object,
                                                                          GQuark                       attribute);
+GTHREE_API
 void                         gthree_object_get_world_matrix_floats      (GthreeObject                *object,
                                                                          float                       *dest);
+GTHREE_API
 void                         gthree_object_get_model_view_matrix_floats (GthreeObject                *object,
                                                                          float                       *dest);
+GTHREE_API
 void                         gthree_object_get_normal_matrix3_floats    (GthreeObject                *object,
                                                                          float                       *dest);
+GTHREE_API
 gboolean                     gthree_object_get_visible                  (GthreeObject                *object);
+GTHREE_API
 void                         gthree_object_set_visible                  (GthreeObject                *object,
                                                                          gboolean                     visible);
+GTHREE_API
 gboolean                     gthree_object_get_is_frustum_culled        (GthreeObject                *object);
+GTHREE_API
 gboolean                     gthree_object_is_in_frustum                (GthreeObject                *object,
                                                                          const graphene_frustum_t    *frustum);
+GTHREE_API
 void                         gthree_object_add_child                    (GthreeObject                *object,
                                                                          GthreeObject                *child);
+GTHREE_API
 void                         gthree_object_remove_child                 (GthreeObject                *object,
                                                                          GthreeObject                *child);
+GTHREE_API
 void                         gthree_object_update                       (GthreeObject                *object);
+GTHREE_API
 void                         gthree_object_destroy                      (GthreeObject                *object);
+GTHREE_API
 GthreeObject *               gthree_object_get_parent                   (GthreeObject                *object);
+GTHREE_API
 GthreeObject *               gthree_object_get_first_child              (GthreeObject                *object);
+GTHREE_API
 GthreeObject *               gthree_object_get_last_child               (GthreeObject                *object);
+GTHREE_API
 GthreeObject *               gthree_object_get_next_sibling             (GthreeObject                *object);
+GTHREE_API
 GthreeObject *               gthree_object_get_previous_sibling         (GthreeObject                *object);
+GTHREE_API
 void                         gthree_object_destroy_all_children         (GthreeObject                *object);
+GTHREE_API
 void                         gthree_object_set_before_render_callback   (GthreeObject                *object,
                                                                          GthreeBeforeRenderCallback   callback);
+GTHREE_API
 GList *                      gthree_object_find_by_type                 (GthreeObject                *object,
                                                                          GType                        g_type);
+GTHREE_API
 void                         gthree_object_get_mesh_extents             (GthreeObject                *object,
                                                                          graphene_box_t              *box);
 
@@ -136,14 +180,20 @@ struct _GthreeObjectIter
   gpointer GTHREE_PRIVATE_FIELD (dummy5);
 };
 
+GTHREE_API
 void     gthree_object_iter_init     (GthreeObjectIter        *iter,
                                       GthreeObject            *root);
+GTHREE_API
 gboolean gthree_object_iter_is_valid (const GthreeObjectIter  *iter);
+GTHREE_API
 gboolean gthree_object_iter_next     (GthreeObjectIter        *iter,
                                       GthreeObject           **child);
+GTHREE_API
 gboolean gthree_object_iter_prev     (GthreeObjectIter        *iter,
                                       GthreeObject           **child);
+GTHREE_API
 void     gthree_object_iter_remove   (GthreeObjectIter        *iter);
+GTHREE_API
 void     gthree_object_iter_destroy  (GthreeObjectIter        *iter);
 
 G_END_DECLS

--- a/gthree/gthreeorthographiccamera.h
+++ b/gthree/gthreeorthographiccamera.h
@@ -26,23 +26,33 @@ typedef struct {
 
 } GthreeOrthographicCameraClass;
 
+GTHREE_API
 GType gthree_orthographic_camera_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeOrthographicCamera *gthree_orthographic_camera_new (float left, float right,
                                                           float top, float bottom,
                                                           float near, float far);
 
+GTHREE_API
 void  gthree_orthographic_camera_set_left   (GthreeOrthographicCamera *orthographic,
                                              float                     left);
+GTHREE_API
 float gthree_orthographic_camera_get_left   (GthreeOrthographicCamera *orthographic);
+GTHREE_API
 void  gthree_orthographic_camera_set_right  (GthreeOrthographicCamera *orthographic,
                                              float                     right);
+GTHREE_API
 float gthree_orthographic_camera_get_right  (GthreeOrthographicCamera *orthographic);
+GTHREE_API
 void  gthree_orthographic_camera_set_top    (GthreeOrthographicCamera *orthographic,
                                              float                     top);
+GTHREE_API
 float gthree_orthographic_camera_get_top    (GthreeOrthographicCamera *orthographic);
+GTHREE_API
 void  gthree_orthographic_camera_set_bottom (GthreeOrthographicCamera *orthographic,
                                              float                     bottom);
+GTHREE_API
 float gthree_orthographic_camera_get_bottom (GthreeOrthographicCamera *orthographic);
 
 G_END_DECLS

--- a/gthree/gthreepass.h
+++ b/gthree/gthreepass.h
@@ -60,15 +60,20 @@ typedef struct {
 } GthreePassClass;
 
 
+GTHREE_API
 GType gthree_pass_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 void gthree_pass_set_enabled (GthreePass         *pass,
                               gboolean            enabled);
+GTHREE_API
 void gthree_pass_set_clear   (GthreePass         *pass,
                               gboolean            clear);
+GTHREE_API
 void gthree_pass_resize      (GthreePass         *pass,
                               int                 width,
                               int                 height);
+GTHREE_API
 void gthree_pass_render      (GthreePass         *pass,
                               GthreeRenderer     *renderer,
                               GthreeRenderTarget *write_buffer,
@@ -89,9 +94,12 @@ typedef struct _GthreeFullscreenQuadPass GthreeFullscreenQuadPass;
                                                   GTHREE_TYPE_FULLSCREEN_QUAD_PASS))
 #define GTHREE_FULLSCREEN_QUAD_PASS_GET_CLASS(inst) (G_TYPE_INSTANCE_GET_CLASS ((inst), GTHREE_TYPE_FULLSCREEN_QUAD_PASS, GthreeFullscreenQuadPassClass))
 
+GTHREE_API
 GType gthree_fullscreen_quad_pass_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreePass *gthree_fullscreen_quad_pass_new  (GthreeMaterial *material);
+GTHREE_API
 void        gthree_fullscreen_quad_pass_set_material (GthreeFullscreenQuadPass *pass,
                                                       GthreeMaterial *material);
 
@@ -115,8 +123,10 @@ typedef struct _GthreeShaderPass GthreeShaderPass;
                                                   GTHREE_TYPE_SHADER_PASS))
 #define GTHREE_SHADER_PASS_GET_CLASS(inst) (G_TYPE_INSTANCE_GET_CLASS ((inst), GTHREE_TYPE_SHADER_PASS, GthreeShaderPassClass))
 
+GTHREE_API
 GType gthree_shader_pass_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreePass *gthree_shader_pass_new  (GthreeShader *shader, const char *texture_id);
 
 typedef struct _GthreeRenderPass GthreeRenderPass;
@@ -130,12 +140,15 @@ typedef struct _GthreeRenderPass GthreeRenderPass;
                                                   GTHREE_TYPE_RENDER_PASS))
 #define GTHREE_RENDER_PASS_GET_CLASS(inst) (G_TYPE_INSTANCE_GET_CLASS ((inst), GTHREE_TYPE_RENDER_PASS, GthreeRenderPassClass))
 
+GTHREE_API
 GType gthree_render_pass_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreePass *gthree_render_pass_new  (GthreeScene *scene,
                                      GthreeCamera *camera,
                                      GthreeMaterial *override_material);
 
+GTHREE_API
 void gthree_render_pass_set_clear_depth (GthreeRenderPass *render_pass,
                                          gboolean          clear_depth);
 
@@ -151,9 +164,12 @@ typedef struct _GthreeClearPass GthreeClearPass;
                                                   GTHREE_TYPE_CLEAR_PASS))
 #define GTHREE_CLEAR_PASS_GET_CLASS(inst) (G_TYPE_INSTANCE_GET_CLASS ((inst), GTHREE_TYPE_CLEAR_PASS, GthreeClearPassClass))
 
+GTHREE_API
 GType gthree_clear_pass_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreePass *gthree_clear_pass_new  (const GdkRGBA *color);
+GTHREE_API
 void gthree_clear_pass_set_clear_depth (GthreeClearPass *clear_pass,
                                         gboolean clear_depth);
 
@@ -168,8 +184,10 @@ typedef struct _GthreeBloomPass GthreeBloomPass;
                                                   GTHREE_TYPE_BLOOM_PASS))
 #define GTHREE_BLOOM_PASS_GET_CLASS(inst) (G_TYPE_INSTANCE_GET_CLASS ((inst), GTHREE_TYPE_BLOOM_PASS, GthreeBloomPassClass))
 
+GTHREE_API
 GType gthree_bloom_pass_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreePass *gthree_bloom_pass_new  (float strength, float sigma, int resolution);
 
 G_END_DECLS

--- a/gthree/gthreeperspectivecamera.h
+++ b/gthree/gthreeperspectivecamera.h
@@ -26,15 +26,21 @@ typedef struct {
 
 } GthreePerspectiveCameraClass;
 
+GTHREE_API
 GType gthree_perspective_camera_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreePerspectiveCamera *gthree_perspective_camera_new (float fov, float aspect, float near, float far);
 
+GTHREE_API
 void  gthree_perspective_camera_set_aspect (GthreePerspectiveCamera *perspective,
                                             float                    aspect);
+GTHREE_API
 float gthree_perspective_camera_get_aspect (GthreePerspectiveCamera *perspective);
+GTHREE_API
 void  gthree_perspective_camera_set_fov    (GthreePerspectiveCamera *perspective,
                                             float                    aspect);
+GTHREE_API
 float gthree_perspective_camera_get_fov    (GthreePerspectiveCamera *perspective);
 
 G_END_DECLS

--- a/gthree/gthreepointlight.h
+++ b/gthree/gthreepointlight.h
@@ -26,16 +26,22 @@ typedef struct {
 
 } GthreePointLightClass;
 
+GTHREE_API
 GType gthree_point_light_get_type (void) G_GNUC_CONST;
+GTHREE_API
 GthreePointLight *gthree_point_light_new (const GdkRGBA *color,
                                           float intensity,
                                           float distance);
 
+GTHREE_API
 void  gthree_point_light_set_distance (GthreePointLight *light,
                                        float             distance);
+GTHREE_API
 float gthree_point_light_get_distance (GthreePointLight *light);
+GTHREE_API
 void  gthree_point_light_set_decay    (GthreePointLight *light,
                                        float             decay);
+GTHREE_API
 float gthree_point_light_get_decay    (GthreePointLight *light);
 
 G_END_DECLS

--- a/gthree/gthreeprimitives.h
+++ b/gthree/gthreeprimitives.h
@@ -9,15 +9,18 @@
 
 G_BEGIN_DECLS
 
+GTHREE_API
 GthreeGeometry *gthree_geometry_new_box           (float width,
                                                    float height,
                                                    float depth,
                                                    int   width_segments,
                                                    int   height_segments,
                                                    int   depth_segments);
+GTHREE_API
 GthreeGeometry *gthree_geometry_new_sphere        (float radius,
                                                    int   widthSegments,
                                                    int   heightSegments);
+GTHREE_API
 GthreeGeometry *gthree_geometry_new_sphere_full   (float radius,
                                                    int   widthSegments,
                                                    int   heightSegments,
@@ -25,8 +28,10 @@ GthreeGeometry *gthree_geometry_new_sphere_full   (float radius,
                                                    float phiLength,
                                                    float thetaStart,
                                                    float thetaLength);
+GTHREE_API
 GthreeGeometry *gthree_geometry_new_cylinder      (float radius,
                                                    float length);
+GTHREE_API
 GthreeGeometry *gthree_geometry_new_cylinder_full (float    radiusTop,
                                                    float    radiusBottom,
                                                    float    height,
@@ -35,13 +40,16 @@ GthreeGeometry *gthree_geometry_new_cylinder_full (float    radiusTop,
                                                    gboolean openEnded,
                                                    float    thetaStart,
                                                    float    thetaLength);
+GTHREE_API
 GthreeGeometry *gthree_geometry_new_torus         (float    radius,
                                                    float    tube);
+GTHREE_API
 GthreeGeometry *gthree_geometry_new_torus_full    (float    radius,
                                                    float    tube,
                                                    int      radialSegments,
                                                    int      tubularSegments,
                                                    float    arc);
+GTHREE_API
 GthreeGeometry *gthree_geometry_new_plane          (float width,
                                                     float height,
                                                     int   width_segments,

--- a/gthree/gthreeprogram.h
+++ b/gthree/gthreeprogram.h
@@ -87,27 +87,38 @@ typedef struct {
 
 } GthreeProgramParameters;
 
+GTHREE_API
 GType gthree_program_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeProgram *gthree_program_new (GthreeShader *shader,
                                    GthreeProgramParameters *parameters,
                                    GthreeRenderer *renderer);
 
+GTHREE_API
 void gthree_program_use                                   (GthreeProgram *program);
+GTHREE_API
 gint gthree_program_lookup_uniform_location               (GthreeProgram *program,
                                                            GQuark         uniform);
+GTHREE_API
 gint gthree_program_lookup_attribute_location             (GthreeProgram *program,
                                                            GQuark         attribute);
+GTHREE_API
 GHashTable * gthree_program_get_attribute_locations (GthreeProgram *program);
+GTHREE_API
 gint gthree_program_lookup_uniform_location_from_string   (GthreeProgram *program,
                                                            const char    *uniform);
+GTHREE_API
 gint gthree_program_lookup_attribute_location_from_string (GthreeProgram *program,
                                                            const char    *attribute);
 
 typedef struct _GthreeProgramCache GthreeProgramCache;
 
+GTHREE_API
 GthreeProgramCache *gthree_program_cache_new  (void);
+GTHREE_API
 void                gthree_program_cache_free (GthreeProgramCache      *cache);
+GTHREE_API
 GthreeProgram *     gthree_program_cache_get  (GthreeProgramCache      *cache,
                                                GthreeShader            *shader,
                                                GthreeProgramParameters *parameters,

--- a/gthree/gthreequaternioninterpolant.h
+++ b/gthree/gthreequaternioninterpolant.h
@@ -28,8 +28,10 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeQuaternionInterpolant, g_object_unref)
 
+GTHREE_API
 GType gthree_quaternion_interpolant_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeInterpolant * gthree_quaternion_interpolant_new (GthreeAttributeArray *parameter_positions,
                                                        GthreeAttributeArray *sample_values);
 

--- a/gthree/gthreequaternionkeyframetrack.h
+++ b/gthree/gthreequaternionkeyframetrack.h
@@ -28,8 +28,10 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeQuaternionKeyframeTrack, g_object_unref)
 
+GTHREE_API
 GType gthree_quaternion_keyframe_track_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeKeyframeTrack *gthree_quaternion_keyframe_track_new (const char *name,
                                                            GthreeAttributeArray *times,
                                                            GthreeAttributeArray *values);

--- a/gthree/gthreerenderer.h
+++ b/gthree/gthreerenderer.h
@@ -29,45 +29,70 @@ typedef struct {
 
 } GthreeRendererClass;
 
+GTHREE_API
 GthreeRenderer *gthree_renderer_new ();
+GTHREE_API
 GType gthree_renderer_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 void                gthree_renderer_set_size                  (GthreeRenderer     *renderer,
                                                                int                 width,
                                                                int                 height);
+GTHREE_API
 int                 gthree_renderer_get_width                 (GthreeRenderer     *renderer);
+GTHREE_API
 int                 gthree_renderer_get_height                (GthreeRenderer     *renderer);
+GTHREE_API
 int                 gthree_renderer_get_drawing_buffer_width  (GthreeRenderer     *renderer);
+GTHREE_API
 int                 gthree_renderer_get_drawing_buffer_height (GthreeRenderer     *renderer);
+GTHREE_API
 void                gthree_renderer_set_autoclear             (GthreeRenderer     *renderer,
                                                                gboolean            auto_clear);
+GTHREE_API
 gboolean            gthree_renderer_get_autoclear             (GthreeRenderer     *renderer);
+GTHREE_API
 void                gthree_renderer_set_autoclear_color       (GthreeRenderer     *renderer,
                                                                gboolean            clear_color);
+GTHREE_API
 gboolean            gthree_renderer_get_autoclear_color       (GthreeRenderer     *renderer);
+GTHREE_API
 void                gthree_renderer_set_autoclear_depth       (GthreeRenderer     *renderer,
                                                                gboolean            clear_depth);
+GTHREE_API
 gboolean            gthree_renderer_get_autoclear_depth       (GthreeRenderer     *renderer);
+GTHREE_API
 void                gthree_renderer_set_autoclear_stencil     (GthreeRenderer     *renderer,
                                                                gboolean            clear_stencil);
+GTHREE_API
 gboolean            gthree_renderer_get_autoclear_stencil     (GthreeRenderer     *renderer);
+GTHREE_API
 void                gthree_renderer_set_clear_color           (GthreeRenderer     *renderer,
                                                                GdkRGBA            *color);
+GTHREE_API
 const GdkRGBA      *gthree_renderer_get_clear_color           (GthreeRenderer     *renderer);
+GTHREE_API
 void                gthree_renderer_set_gamma_factor          (GthreeRenderer     *renderer,
                                                                float               factor);
+GTHREE_API
 float               gthree_renderer_get_gamma_factor          (GthreeRenderer     *renderer);
+GTHREE_API
 void                gthree_renderer_set_render_target         (GthreeRenderer     *renderer,
                                                                GthreeRenderTarget *target,
                                                                int                 active_cube_target,
                                                                int                 active_mipmap_level);
+GTHREE_API
 GthreeRenderTarget *gthree_renderer_get_render_target         (GthreeRenderer     *renderer);
+GTHREE_API
 void                gthree_renderer_clear                     (GthreeRenderer     *renderer,
                                                                gboolean            color,
                                                                gboolean            depth,
                                                                gboolean            stencil);
+GTHREE_API
 void                gthree_renderer_clear_depth               (GthreeRenderer     *renderer);
+GTHREE_API
 void                gthree_renderer_clear_color               (GthreeRenderer     *renderer);
+GTHREE_API
 void                gthree_renderer_render                    (GthreeRenderer     *renderer,
                                                                GthreeScene        *scene,
                                                                GthreeCamera       *camera);

--- a/gthree/gthreerendertarget.h
+++ b/gthree/gthreerendertarget.h
@@ -34,8 +34,10 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeRenderTarget, g_object_unref)
 
+GTHREE_API
 GType gthree_render_target_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeRenderTarget *gthree_render_target_new_full (int width,
                                                    int height,
                                                    GthreeWrapping wrap_t,
@@ -51,25 +53,38 @@ GthreeRenderTarget *gthree_render_target_new_full (int width,
                                                    gboolean stencil_buffer,
                                                    GthreeTexture *depth_texture);
 
+GTHREE_API
 GthreeRenderTarget *gthree_render_target_new (int width,
                                               int height);
+GTHREE_API
 GthreeRenderTarget *gthree_render_target_clone (GthreeRenderTarget *target);
 
+GTHREE_API
 int            gthree_render_target_get_width         (GthreeRenderTarget *target);
+GTHREE_API
 int            gthree_render_target_get_height        (GthreeRenderTarget *target);
+GTHREE_API
 void           gthree_render_target_set_size          (GthreeRenderTarget *target,
                                                        int                 width,
                                                        int                 height);
+GTHREE_API
 GthreeTexture *gthree_render_target_get_texture       (GthreeRenderTarget *target);
+GTHREE_API
 gboolean       gthree_render_target_get_depth_buffer  (GthreeRenderTarget *target);
+GTHREE_API
 void           gthree_render_target_set_depth_buffer  (GthreeRenderTarget *target,
                                                        gboolean            depth_buffer);
+GTHREE_API
 gboolean       gthree_render_target_get_stencil_buffer  (GthreeRenderTarget *target);
+GTHREE_API
 void           gthree_render_target_set_stencil_buffer  (GthreeRenderTarget *target,
                                                        gboolean            stencil_buffer);
+GTHREE_API
 GthreeTexture *gthree_render_target_get_depth_texture (GthreeRenderTarget *target);
+GTHREE_API
 void           gthree_render_target_set_depth_texture (GthreeRenderTarget *target,
                                                        GthreeTexture *texture);
+GTHREE_API
 void           gthree_render_target_update_mipmap     (GthreeRenderTarget *target);
 
 G_END_DECLS

--- a/gthree/gthreeresource.h
+++ b/gthree/gthreeresource.h
@@ -30,17 +30,26 @@ typedef struct {
   void (*unrealize) (GthreeResource *resource);
 } GthreeResourceClass;
 
+GTHREE_API
 GType gthree_resource_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 void gthree_resources_unrealize_all_for    (GdkGLContext *context);
+GTHREE_API
 void gthree_resources_unrealize_unused_for (GdkGLContext *context);
 
+GTHREE_API
 void     gthree_resource_set_realized_for (GthreeResource *resource,
                                            GdkGLContext   *context);
+GTHREE_API
 gboolean gtahree_resource_is_realized      (GthreeResource *resource);
+GTHREE_API
 void     gthree_resource_unrealize        (GthreeResource *resource);
+GTHREE_API
 gboolean gtahree_resource_is_used         (GthreeResource *resource);
+GTHREE_API
 void     gthree_resource_use              (GthreeResource *resource);
+GTHREE_API
 void     gthree_resource_unuse            (GthreeResource *resource);
 
 G_END_DECLS

--- a/gthree/gthreescene.h
+++ b/gthree/gthreescene.h
@@ -29,15 +29,22 @@ typedef struct {
 
 } GthreeSceneClass;
 
+GTHREE_API
 GType  gthree_scene_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeScene *gthree_scene_new ();
 
+GTHREE_API
 GthreeMaterial *gthree_scene_get_override_material  (GthreeScene   *scene);
+GTHREE_API
 const GdkRGBA * gthree_scene_get_background_color   (GthreeScene   *scene);
+GTHREE_API
 void            gthree_scene_set_background_color   (GthreeScene   *scene,
                                                      GdkRGBA       *color);
+GTHREE_API
 GthreeTexture * gthree_scene_get_background_texture (GthreeScene   *scene);
+GTHREE_API
 void            gthree_scene_set_background_texture (GthreeScene   *scene,
                                                      GthreeTexture *texture);
 

--- a/gthree/gthreeshader.h
+++ b/gthree/gthreeshader.h
@@ -27,32 +27,48 @@ typedef struct {
 
 } GthreeShaderClass;
 
+GTHREE_API
 GType gthree_shader_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeShader *  gthree_shader_new   (GPtrArray *defines,
                                      GthreeUniforms *uniforms,
                                      const char *vertex_shader_text,
                                      const char *fragment_shader_text);
 
+GTHREE_API
 GthreeShader *  gthree_shader_clone                                (GthreeShader  *shader);
+GTHREE_API
 GPtrArray      *gthree_shader_get_defines                          (GthreeShader  *shader);
+GTHREE_API
 void            gthree_shader_set_defines                          (GthreeShader  *shader,
                                                                     GPtrArray     *defines);
+GTHREE_API
 GthreeUniforms *gthree_shader_get_uniforms                         (GthreeShader  *shader);
+GTHREE_API
 const char *    gthree_shader_get_vertex_shader_text               (GthreeShader  *shader);
+GTHREE_API
 const char *    gthree_shader_get_fragment_shader_text             (GthreeShader  *shader);
+GTHREE_API
 void            gthree_shader_update_uniform_locations_for_program (GthreeShader  *shader,
                                                                     GthreeProgram *program);
+GTHREE_API
 gboolean        gthree_shader_equal                                (GthreeShader  *a,
                                                                     GthreeShader  *b);
+GTHREE_API
 guint           gthree_shader_hash                                 (GthreeShader  *shader);
+GTHREE_API
 void            gthree_shader_set_name                             (GthreeShader *shader,
                                                                     const char   *name);
+GTHREE_API
 const char *    gthree_shader_get_name                             (GthreeShader *shader);
 
+GTHREE_API
 GthreeShader *gthree_get_shader_from_library   (const char *name);
+GTHREE_API
 GthreeShader *gthree_clone_shader_from_library (const char *name);
 
+GTHREE_API
 GArray *gthree_convolution_shader_build_kernel (float sigma);
 
 G_END_DECLS

--- a/gthree/gthreeshadermaterial.h
+++ b/gthree/gthreeshadermaterial.h
@@ -26,18 +26,26 @@ typedef struct {
 
 } GthreeShaderMaterialClass;
 
+GTHREE_API
 GType gthree_shader_material_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeShaderMaterial *gthree_shader_material_new (GthreeShader *shader);
 
+GTHREE_API
 GthreeShadingType gthree_shader_material_get_shading_type  (GthreeShaderMaterial *shader);
+GTHREE_API
 void              gthree_shader_material_set_shading_type  (GthreeShaderMaterial *shader,
                                                             GthreeShadingType     shading_type);
+GTHREE_API
 void              gthree_shader_material_set_vertex_colors (GthreeShaderMaterial *shader,
                                                             gboolean              vertex_color);
+GTHREE_API
 gboolean          gthree_shader_material_get_vertex_colors (GthreeShaderMaterial *shader);
+GTHREE_API
 void              gthree_shader_material_set_use_lights    (GthreeShaderMaterial *shader,
                                                             gboolean              use_lights);
+GTHREE_API
 gboolean          gthree_shader_material_get_use_lights    (GthreeShaderMaterial *shader);
 
 G_END_DECLS

--- a/gthree/gthreeskeleton.h
+++ b/gthree/gthreeskeleton.h
@@ -30,18 +30,25 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeSkeleton, g_object_unref)
 
+GTHREE_API
 GType gthree_skeleton_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeSkeleton *gthree_skeleton_new  (GthreeBone **bones,
                                       int n_bones,
                                       graphene_matrix_t *bone_inverses);
 
+GTHREE_API
 int         gthree_skeleton_get_n_bones        (GthreeSkeleton *skeleton);
+GTHREE_API
 GthreeBone *gthree_skeleton_get_bone           (GthreeSkeleton *skeleton,
                                                 int             index);
+GTHREE_API
 GthreeBone *gthree_skeleton_get_bone_by_name   (GthreeSkeleton *skeleton,
                                                 const char     *name);
+GTHREE_API
 void        gthree_skeleton_calculate_inverses (GthreeSkeleton *skeleton);
+GTHREE_API
 void        gthree_skeleton_pose               (GthreeSkeleton *skeleton);
 
 

--- a/gthree/gthreeskinnedmesh.h
+++ b/gthree/gthreeskinnedmesh.h
@@ -28,20 +28,29 @@ typedef struct {
 
 } GthreeSkinnedMeshClass;
 
+GTHREE_API
 GType gthree_skinned_mesh_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeSkinnedMesh *gthree_skinned_mesh_new (GthreeGeometry *geometry,
                                             GthreeMaterial *material);
 
+GTHREE_API
 GthreeSkeleton *         gthree_skinned_mesh_get_skeleton            (GthreeSkinnedMesh       *mesh);
+GTHREE_API
 const graphene_matrix_t *gthree_skinned_mesh_get_bind_matrix         (GthreeSkinnedMesh       *mesh);
+GTHREE_API
 const graphene_matrix_t *gthree_skinned_mesh_get_inverse_bind_matrix (GthreeSkinnedMesh       *mesh);
+GTHREE_API
 void                     gthree_skinned_mesh_set_bind_mode           (GthreeSkinnedMesh       *mesh,
                                                                       GthreeBindMode           bind_mode);
+GTHREE_API
 void                     gthree_skinned_mesh_normalize_skin_weights  (GthreeSkinnedMesh       *mesh);
+GTHREE_API
 void                     gthree_skinned_mesh_bind                    (GthreeSkinnedMesh       *mesh,
                                                                       GthreeSkeleton          *skeleton,
                                                                       const graphene_matrix_t *bind_matrix);
+GTHREE_API
 void                     gthree_skinned_mesh_pose                    (GthreeSkinnedMesh       *mesh);
 
 

--- a/gthree/gthreetexture.h
+++ b/gthree/gthreetexture.h
@@ -33,52 +33,83 @@ typedef struct {
   void (*load) (GthreeTexture *texture, int slot);
 } GthreeTextureClass;
 
+GTHREE_API
 GType gthree_texture_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeTexture *gthree_texture_new (GdkPixbuf *pixbuf);
 
+GTHREE_API
 const graphene_vec2_t *gthree_texture_get_repeat           (GthreeTexture        *texture);
+GTHREE_API
 const graphene_vec2_t *gthree_texture_get_offset           (GthreeTexture        *texture);
+GTHREE_API
 gboolean               gthree_texture_get_generate_mipmaps (GthreeTexture        *texture);
+GTHREE_API
 void                   gthree_texture_set_generate_mipmaps (GthreeTexture        *texture,
                                                             gboolean              generate_mipmaps);
+GTHREE_API
 void                   gthree_texture_set_mapping          (GthreeTexture        *texture,
                                                             GthreeMapping         mapping);
+GTHREE_API
 GthreeMapping          gthree_texture_get_mapping          (GthreeTexture        *texture);
+GTHREE_API
 void                   gthree_texture_set_wrap_s           (GthreeTexture        *texture,
                                                             GthreeWrapping        wrap_s);
+GTHREE_API
 GthreeWrapping         gthree_texture_get_wrap_s           (GthreeTexture        *texture);
+GTHREE_API
 void                   gthree_texture_set_wrap_t           (GthreeTexture        *texture,
                                                             GthreeWrapping        wrap_t);
+GTHREE_API
 GthreeWrapping         gthree_texture_get_wrap_t           (GthreeTexture        *texture);
+GTHREE_API
 void                   gthree_texture_set_mag_filter       (GthreeTexture        *texture,
                                                             GthreeFilter          mag_filter);
+GTHREE_API
 GthreeFilter           gthree_texture_get_mag_filter       (GthreeTexture        *texture);
+GTHREE_API
 void                   gthree_texture_set_min_filter       (GthreeTexture        *texture,
                                                             GthreeFilter          min_filter);
+GTHREE_API
 GthreeFilter           gthree_texture_get_min_filter       (GthreeTexture        *texture);
+GTHREE_API
 void                   gthree_texture_set_flip_y           (GthreeTexture        *texture,
                                                             gboolean              flip_y);
+GTHREE_API
 gboolean               gthree_texture_get_flip_y           (GthreeTexture        *texture);
+GTHREE_API
 void                   gthree_texture_set_encoding         (GthreeTexture        *texture,
                                                             GthreeEncodingFormat  encoding);
+GTHREE_API
 GthreeEncodingFormat   gthree_texture_get_encoding         (GthreeTexture        *texture);
+GTHREE_API
 void                   gthree_texture_set_format           (GthreeTexture        *texture,
                                                             GthreeTextureFormat   format);
+GTHREE_API
 GthreeTextureFormat    gthree_texture_get_format           (GthreeTexture        *texture);
+GTHREE_API
 void                   gthree_texture_set_data_type        (GthreeTexture        *texture,
                                                             GthreeDataType     type);
+GTHREE_API
 GthreeDataType         gthree_texture_get_data_type        (GthreeTexture        *texture);
+GTHREE_API
 void                   gthree_texture_set_anisotropy       (GthreeTexture        *texture,
                                                             int                   anisotropy);
+GTHREE_API
 int                    gthree_texture_get_anisotropy       (GthreeTexture        *texture);
+GTHREE_API
 void                   gthree_texture_copy_settings        (GthreeTexture        *texture,
                                                             GthreeTexture        *source);
+GTHREE_API
 void                   gthree_texture_set_name             (GthreeTexture        *texture,
                                                             const char           *name);
+GTHREE_API
 const char *           gthree_texture_get_name             (GthreeTexture        *texture);
+GTHREE_API
 void                   gthree_texture_set_uuid             (GthreeTexture        *texture,
                                                             const char           *uuid);
+GTHREE_API
 const char *           gthree_texture_get_uuid             (GthreeTexture        *texture);
 
 G_END_DECLS

--- a/gthree/gthreetypebuiltins.h.template
+++ b/gthree/gthreetypebuiltins.h.template
@@ -7,6 +7,7 @@
 #define __GTHREE_TYPE_BUILTINS_H__
 
 #include <glib-object.h>
+#include <gthree/gthreetypes.h>
 
 G_BEGIN_DECLS
 /*** END file-header ***/
@@ -17,7 +18,7 @@ G_BEGIN_DECLS
 /*** END file-production ***/
 
 /*** BEGIN value-header ***/
-GDK_AVAILABLE_IN_ALL GType @enum_name@_get_type (void) G_GNUC_CONST;
+GTHREE_API GType @enum_name@_get_type (void) G_GNUC_CONST;
 #define @ENUMPREFIX@_TYPE_@ENUMSHORT@ (@enum_name@_get_type ())
 /*** END value-header ***/
 

--- a/gthree/gthreetypes.h
+++ b/gthree/gthreetypes.h
@@ -36,4 +36,10 @@ typedef struct _GthreeAnimationAction GthreeAnimationAction;
 typedef struct _GthreeAnimationMixer GthreeAnimationMixer;
 typedef int GthreeAttributeName;
 
+#if defined (_MSC_VER) && defined (GTHREE_COMPILATION)
+# define GTHREE_API __declspec(dllexport)
+#else
+# define GTHREE_API
+#endif
+
 #endif /* __GTHREE_TYPES_H__ */

--- a/gthree/gthreeuniforms.h
+++ b/gthree/gthreeuniforms.h
@@ -56,6 +56,7 @@ typedef struct {
 
 } GthreeUniformsClass;
 
+GTHREE_API
 GType gthree_uniforms_get_type (void) G_GNUC_CONST;
 
 typedef struct {
@@ -64,88 +65,127 @@ typedef struct {
   gpointer value;
 } GthreeUniformsDefinition;
 
+GTHREE_API
 GthreeUniforms *gthree_uniforms_new   ();
+GTHREE_API
 GthreeUniforms *gthree_uniforms_new_from_definitions (GthreeUniformsDefinition *element, int len);
 
+GTHREE_API
 GthreeUniforms *gthree_get_uniforms_from_library (const char *name);
 
+GTHREE_API
 GthreeUniforms *gthree_uniforms_clone              (GthreeUniforms  *uniforms);
+GTHREE_API
 void            gthree_uniforms_merge              (GthreeUniforms  *uniforms,
                                                     GthreeUniforms  *source);
+GTHREE_API
 void            gthree_uniforms_copy_values        (GthreeUniforms *uniforms,
                                                     GthreeUniforms *source);
+GTHREE_API
 void            gthree_uniforms_add                (GthreeUniforms  *uniforms,
                                                     GthreeUniform   *uniform);
+GTHREE_API
 void            gthree_uniforms_load               (GthreeUniforms  *uniforms,
                                                     GthreeRenderer  *renderer);
+GTHREE_API
 GthreeUniform * gthree_uniforms_lookup             (GthreeUniforms  *uniforms,
                                                     GQuark           name);
+GTHREE_API
 GList  *        gthree_uniforms_get_all            (GthreeUniforms  *uniforms);
+GTHREE_API
 GthreeUniform * gthree_uniforms_lookup_from_string (GthreeUniforms  *uniforms,
                                                     const char      *name);
+GTHREE_API
 void            gthree_uniforms_set_float          (GthreeUniforms  *uniforms,
                                                     const char      *name,
                                                     double           value);
+GTHREE_API
 void            gthree_uniforms_set_float_array    (GthreeUniforms  *uniforms,
                                                     const char      *name,
                                                     GArray          *array);
+GTHREE_API
 void            gthree_uniforms_set_float3_array   (GthreeUniforms  *uniforms,
                                                     const char      *name,
                                                     GArray          *array);
+GTHREE_API
 void            gthree_uniforms_set_int            (GthreeUniforms  *uniforms,
                                                     const char      *name,
                                                     int              value);
+GTHREE_API
 void            gthree_uniforms_set_vec4           (GthreeUniforms  *uniforms,
                                                     const char      *name,
                                                     graphene_vec4_t *value);
+GTHREE_API
 void            gthree_uniforms_set_vec3           (GthreeUniforms  *uniforms,
                                                     const char      *name,
                                                     graphene_vec3_t *value);
+GTHREE_API
 void            gthree_uniforms_set_vec2           (GthreeUniforms  *uniforms,
                                                     const char      *name,
                                                     graphene_vec2_t *value);
+GTHREE_API
 void            gthree_uniforms_set_texture        (GthreeUniforms  *uniforms,
                                                     const char      *name,
                                                     GthreeTexture   *value);
+GTHREE_API
 void            gthree_uniforms_set_color          (GthreeUniforms  *uniforms,
                                                     const char      *name,
                                                     GdkRGBA         *color);
+GTHREE_API
 void            gthree_uniforms_set_uarray         (GthreeUniforms   *uniforms,
                                                     const char      *name,
                                                     GPtrArray       *uarray,
                                                     gboolean         update_existing);
 
+GTHREE_API
 void        gthree_uniform_set_location     (GthreeUniform   *uniform,
                                              int              location);
+GTHREE_API
 void        gthree_uniform_set_needs_update (GthreeUniform   *uniform,
                                              gboolean         needs_update);
+GTHREE_API
 void        gthree_uniform_copy_value       (GthreeUniform   *uniform,
                                              GthreeUniform   *source);
+GTHREE_API
 void        gthree_uniform_set_float        (GthreeUniform   *uniform,
                                              double           value);
+GTHREE_API
 void        gthree_uniform_set_float_array  (GthreeUniform   *uniform,
                                              GArray          *array);
+GTHREE_API
 void        gthree_uniform_set_float3_array (GthreeUniform   *uniform,
                                              GArray          *array);
+GTHREE_API
 void        gthree_uniform_set_int          (GthreeUniform   *uniform,
                                              int              value);
+GTHREE_API
 void        gthree_uniform_set_vec2         (GthreeUniform   *uniform,
                                              graphene_vec2_t *value);
+GTHREE_API
 void        gthree_uniform_set_vec3         (GthreeUniform   *uniform,
                                              graphene_vec3_t *value);
+GTHREE_API
 void        gthree_uniform_set_vec4         (GthreeUniform   *uniform,
                                              graphene_vec4_t *value);
+GTHREE_API
 void        gthree_uniform_set_texture      (GthreeUniform   *uniform,
                                              GthreeTexture   *value);
+GTHREE_API
 void        gthree_uniform_set_color        (GthreeUniform   *uniform,
                                              GdkRGBA         *color);
+GTHREE_API
 void        gthree_uniform_set_uarray       (GthreeUniform   *uniform,
                                              GPtrArray       *uarray,
                                              gboolean         update_existing);
+GTHREE_API
 GPtrArray  *gthree_uniform_get_uarray       (GthreeUniform   *uniform);
+GTHREE_API
 GthreeUniformType gthree_uniform_get_type   (GthreeUniform   *uniform);
+GTHREE_API
 const char *gthree_uniform_get_name         (GthreeUniform   *uniform);
+GTHREE_API
 GQuark      gthree_uniform_get_qname        (GthreeUniform   *uniform);
+GTHREE_API
 void        gthree_uniform_load             (GthreeUniform   *uniform,
                                              GthreeRenderer  *renderer);
 

--- a/gthree/gthreevectorkeyframetrack.h
+++ b/gthree/gthreevectorkeyframetrack.h
@@ -28,8 +28,10 @@ typedef struct {
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC (GthreeVectorKeyframeTrack, g_object_unref)
 
+GTHREE_API
 GType gthree_vector_keyframe_track_get_type (void) G_GNUC_CONST;
 
+GTHREE_API
 GthreeKeyframeTrack *gthree_vector_keyframe_track_new (const char *name,
                                                        GthreeAttributeArray *times,
                                                        GthreeAttributeArray *values);


### PR DESCRIPTION
Hi,

This adds an macro that is currently defined to be __declspec(dllexport) for clang-cl builds so that the public symbols can be exported from the DLL during the build.  This will make builds against MSVC-built GTK+ stack work.

With blessings, thank you!