### PR TITLE
gthree-1.pc: Move json-glib to Requires

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -48,8 +48,8 @@ common_ldflags = []
 gthree_conf = configuration_data()
 gthree_conf.set_quoted('VERSION', meson.project_version())
 
-gthree_packages = ' '.join([ 'glib-2.0', 'gobject-2.0', 'graphene-gobject-1.0', 'gtk+-3.0' ])
-gthree_private_packages = ' '.join([ 'epoxy', 'json-glib-1.0' ])
+gthree_packages = ' '.join([ 'glib-2.0', 'gobject-2.0', 'graphene-gobject-1.0', 'gtk+-3.0', 'json-glib-1.0' ])
+gthree_private_packages = ' '.join([ 'epoxy' ])
 
 # Compat variables for pkgconfig
 pkgconf = configuration_data()


### PR DESCRIPTION
json-glib is included in the public headers thus needs to be in Requires, otherwise it can cause errors on platforms that use alternative interpretation of Requires.private:

```
…/include/gthree-1.0/gthree/gthreeattribute.h:12:10: fatal error: json-glib/json-glib.h: No such file or directory
     #include <json-glib/json-glib.h>
              ^~~~~~~~~~~~~~~~~~~~~~~
```