### PR TITLE
Allow building graphene as a Meson subproject

### DIFF
--- a/gthree/meson.build
+++ b/gthree/meson.build
@@ -195,6 +195,15 @@ libgthree_dep = declare_dependency(sources: gthree_dep_sources,
                                    dependencies: gthree_deps)
 
 if not meson.is_cross_build() and get_option('introspection')
+  extra_gir_args = [
+    '--quiet',
+    '--c-include=gthree/gthree.h',
+    '-DGTHREE_COMPILATION',
+  ]
+  if graphene_is_subproject
+    extra_gir_args = extra_gir_args + ['--add-include-path', graphene_subproject_typelib_dir]
+  endif
+
   gnome.generate_gir(libgthree,
                      sources: gthree_sources + gthree_headers + gthree_marshalers,
                      namespace: 'Gthree',
@@ -204,9 +213,5 @@ if not meson.is_cross_build() and get_option('introspection')
                      export_packages: 'gthree',
                      includes: [ 'GObject-2.0', 'Graphene-1.0', 'GdkPixbuf-2.0', 'Gdk-3.0' ],
                      install: true,
-                     extra_args: [
-                       '--quiet',
-                       '--c-include=gthree/gthree.h',
-                       '-DGTHREE_COMPILATION',
-                     ])
+                     extra_args: extra_gir_args)
 endif

--- a/meson.build
+++ b/meson.build
@@ -26,7 +26,8 @@ libm = cc.find_library('m', required : false)
 
 glib_dep       = dependency('glib-2.0', version: '>= 2.43.2')
 gobject_dep    = dependency('gobject-2.0', version: '>= 2.43.2')
-graphene_dep   = dependency('graphene-gobject-1.0', version: '>= 1.9.7')
+graphene_dep   = dependency('graphene-gobject-1.0', version: '>= 1.9.7',
+                            fallback: ['graphene', 'graphene_dep'])
 gtk_dep        = dependency('gtk+-3.0', version: '>= 3.22')
 epoxy_dep      = dependency('epoxy', version: '>= 1.4')
 json_glib_dep  = dependency('json-glib-1.0', version: '>= 1.2.0')
@@ -35,6 +36,14 @@ gthree_prefix = get_option('prefix')
 gthree_libdir = join_paths(gthree_prefix, get_option('libdir'))
 gthree_includedir = join_paths(gthree_prefix, get_option('includedir'))
 gthree_datadir = join_paths(gthree_prefix, get_option('datadir'))
+
+if graphene_dep.type_name() == 'internal'
+  graphene_is_subproject = true
+  graphene_subproject_typelib_dir = join_paths(meson.build_root(), 'subprojects', 'graphene', 'src')
+else
+  graphene_is_subproject = false
+  graphene_subproject_typelib_dir = ''
+endif
 
 # Maintain version scheme with libtool
 gthree_soversion = 0


### PR DESCRIPTION
If a new enough version of Graphene isn't installed, Meson will now
automatically clone the repo from Github and build that.

This can be disabled with the `--wrap-mode=nodownload` configure time
option.
