### PR TITLE
Split out gtk3 dependency into libgthree-gtk3

### DIFF
--- a/docs/gthree-docs.xml
+++ b/docs/gthree-docs.xml
@@ -29,12 +29,6 @@
     </chapter>
   </part>
 
-  <part id="widget">
-    <title>Widget</title>
-
-    <xi:include href="xml/gthreearea.xml" />
-  </part>
-
   <part id="base-types">
     <title>Types</title>
 

--- a/docs/gthree-sections.txt
+++ b/docs/gthree-sections.txt
@@ -128,24 +128,6 @@ gthree_ambient_light_get_type
 </SECTION>
 
 <SECTION>
-<FILE>gthreearea</FILE>
-GthreeArea
-GthreeAreaClass
-<SUBSECTION>
-gthree_area_new
-gthree_area_set_camera
-gthree_area_get_camera
-gthree_area_set_scene
-gthree_area_get_scene
-gthree_area_get_renderer
-<SUBSECTION Standard>
-GTHREE_AREA
-GTHREE_IS_AREA
-GTHREE_TYPE_AREA
-gthree_area_get_type
-</SECTION>
-
-<SECTION>
 <FILE>gthreeattribute</FILE>
 GthreeAttribute
 GthreeAttributeArray

--- a/docs/meson.build
+++ b/docs/meson.build
@@ -5,6 +5,10 @@ private_headers = [
   'gthreepropertymixerprivate.h',
 ]
 
+gtk3_headers = [
+  'gthreearea.h',
+]
+
 content_files = [
   'overview.xml',
   'resources.xml',
@@ -33,10 +37,37 @@ gnome.gtkdoc('gthree',
   scan_args: [
     '--rebuild-types',
     '--ignore-decorators=GTHREE_API',
-    '--ignore-headers=' + ' '.join(private_headers),
+    '--ignore-headers=' + ' '.join(private_headers + gtk3_headers),
   ],
   mkdb_args: [
     '--default-include=gthree/gthree.h',
+  ],
+  fixxref_args: [
+    '--html-dir=@0@'.format(docpath),
+    '--extra-dir=@0@'.format(join_paths(glib_docpath, 'glib')),
+    '--extra-dir=@0@'.format(join_paths(glib_docpath, 'gobject')),
+    '--extra-dir=@0@'.format(join_paths(glib_docpath, 'gio')),
+    '--extra-dir=@0@'.format(join_paths(gtk_docpath, 'gtk')),
+    '--extra-dir=@0@'.format(join_paths(gtk_docpath, 'gdk')),
+    '--extra-dir=@0@'.format(join_paths(graphene_docpath, 'graphene')),
+  ],
+  content_files: content_files,
+  expand_content_files: expand_content_files,
+  install: true,
+)
+
+gnome.gtkdoc('gthree-gtk3',
+  main_xml: 'gthree-gtk3-docs.xml',
+  src_dir: gthree_inc,
+  dependencies: libgthree_gtk3_dep,
+  gobject_typesfile: 'gthree-gtk3.types',
+  scan_args: [
+    '--rebuild-types',
+    '--ignore-decorators=GTHREE_API',
+    '--ignore-headers=' + ' '.join(private_headers),
+  ],
+  mkdb_args: [
+    '--default-include=gthree/gthreearea.h',
   ],
   fixxref_args: [
     '--html-dir=@0@'.format(docpath),

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -35,12 +35,12 @@ libexample_sources = ['utils.c', 'prop-editor.c']  + example_resources
 libexample = static_library(
   'libexample',
   libexample_sources,
-  dependencies: [libgthree_dep, libm],
+  dependencies: [libgthree_gtk3_dep, libm],
 )
 
 example_dep = declare_dependency(
   link_whole: libexample,
-  dependencies: [libgthree_dep, libm]
+  dependencies: [libgthree_gtk3_dep, libm]
 )
 
 foreach example_name : examples

--- a/examples/prop-editor.h
+++ b/examples/prop-editor.h
@@ -1,3 +1,4 @@
 #include <gthree/gthree.h>
+#include <gthree/gthreearea.h>
 
 GtkWidget * property_editor_widget_new (GObject  *object, const char *name);

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -1,4 +1,5 @@
 #include <gthree/gthree.h>
+#include <gthree/gthreearea.h>
 
 GdkPixbuf *examples_load_pixbuf (const char *file);
 GthreeGeometry *examples_load_geometry (const char *name);

--- a/gthree-gtk3-1.0.pc.in
+++ b/gthree-gtk3-1.0.pc.in
@@ -1,0 +1,11 @@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
+
+Name: Gthree Gtk3
+Description: Gtk3 widgets for Gthree
+Version: 1.0
+Requires: @GTHREE_GTK3_PACKAGES@
+Libs: -L${libdir} -lgthree-gtk3-1
+Cflags: -I${includedir}/gthree-gtk3-1.0

--- a/gthree/gthree.h
+++ b/gthree/gthree.h
@@ -4,12 +4,10 @@
 #define __GTHREE_H_INSIDE__
 
 #include <glib-object.h>
-#include <gdk/gdk.h>
 #include <gthree/gthreetypes.h>
 #include <gthree/gthreetypebuiltins.h>
 #include <gthree/gthreeenums.h>
 #include <gthree/gthreeattribute.h>
-#include <gthree/gthreearea.h>
 #include <gthree/gthreemeshmaterial.h>
 #include <gthree/gthreemeshbasicmaterial.h>
 #include <gthree/gthreecamera.h>

--- a/gthree/gthreearea.h
+++ b/gthree/gthreearea.h
@@ -1,14 +1,9 @@
 #ifndef __GTHREE_AREA_H__
 #define __GTHREE_AREA_H__
 
-#if !defined (__GTHREE_H_INSIDE__) && !defined (GTHREE_COMPILATION)
-#error "Only <gthree/gthree.h> can be included directly."
-#endif
-
 #include <gtk/gtk.h>
 
-#include <gthree/gthreescene.h>
-#include <gthree/gthreecamera.h>
+#include <gthree/gthree.h>
 
 G_BEGIN_DECLS
 

--- a/gthree/gthreegeometry.h
+++ b/gthree/gthreegeometry.h
@@ -7,7 +7,6 @@
 
 #include <graphene.h>
 
-#include <gdk/gdk.h>
 #include <gthree/gthreeobject.h>
 
 G_BEGIN_DECLS

--- a/gthree/gthreelight.h
+++ b/gthree/gthreelight.h
@@ -6,7 +6,6 @@
 #endif
 
 #include <gthree/gthreeobject.h>
-#include <gdk/gdk.h>
 
 G_BEGIN_DECLS
 

--- a/gthree/gthreelightshadow.h
+++ b/gthree/gthreelightshadow.h
@@ -7,7 +7,6 @@
 
 #include <graphene.h>
 
-#include <gdk/gdk.h>
 #include <gthree/gthreeobject.h>
 
 G_BEGIN_DECLS

--- a/gthree/gthreerendertarget.c
+++ b/gthree/gthreerendertarget.c
@@ -531,14 +531,14 @@ gthree_render_target_download (GthreeRenderTarget *target,
                                gsize       stride)
 {
   GthreeRenderTargetPrivate *priv = gthree_render_target_get_instance_private (target);
-  GdkRectangle all = { 0, 0, priv->width, priv->height };
+  cairo_rectangle_int_t all = { 0, 0, priv->width, priv->height };
 
   gthree_render_target_download_area (target, &all, data, stride);
 }
 
 void
 gthree_render_target_download_area (GthreeRenderTarget *target,
-                                    const GdkRectangle *area,
+                                    const cairo_rectangle_int_t *area,
                                     guchar     *data,
                                     gsize       stride)
 {

--- a/gthree/gthreerendertarget.h
+++ b/gthree/gthreerendertarget.h
@@ -6,6 +6,7 @@
 #endif
 
 #include <gio/gio.h>
+#include <cairo.h>
 #include <gthree/gthreeenums.h>
 #include <gthree/gthreetypes.h>
 #include <gthree/gthreeresource.h>
@@ -74,7 +75,7 @@ void           gthree_render_target_download          (GthreeRenderTarget *targe
                                                        guchar     *data,
                                                        gsize       stride);
 void           gthree_render_target_download_area     (GthreeRenderTarget *target,
-                                                       const GdkRectangle *area,
+                                                       const cairo_rectangle_int_t *area,
                                                        guchar     *data,
                                                        gsize       stride);
 

--- a/gthree/gthreeresource.h
+++ b/gthree/gthreeresource.h
@@ -6,7 +6,6 @@
 #endif
 
 #include <glib-object.h>
-#include <gdk/gdk.h>
 #include <gthree/gthreetypes.h>
 
 G_BEGIN_DECLS

--- a/gthree/gthreetexture.h
+++ b/gthree/gthreetexture.h
@@ -7,6 +7,7 @@
 
 #include <glib-object.h>
 #include <gdk-pixbuf/gdk-pixbuf.h>
+#include <cairo.h>
 #include <graphene.h>
 #include <gthree/gthreetypes.h>
 #include <gthree/gthreeenums.h>

--- a/gthree/gthreeuniforms.h
+++ b/gthree/gthreeuniforms.h
@@ -2,7 +2,6 @@
 #define __GTHREE_UNIFORMS_H__
 
 #include <glib-object.h>
-#include <gdk/gdk.h>
 #include <graphene.h>
 
 #include <gthree/gthreetypes.h>

--- a/gthree/meson.build
+++ b/gthree/meson.build
@@ -1,7 +1,17 @@
+if not meson.is_cross_build() and get_option('introspection')
+  extra_gir_args = [
+    '--quiet',
+    '--c-include=gthree/gthree.h',
+    '-DGTHREE_COMPILATION',
+  ]
+  if graphene_is_subproject
+    extra_gir_args = extra_gir_args + ['--add-include-path', graphene_subproject_typelib_dir]
+  endif
+endif
+
 gthree_sources = [
     'gthreeattribute.c',
     'gthreeambientlight.c',
-    'gthreearea.c',
     'gthreemeshbasicmaterial.c',
     'gthreebone.c',
     'gthreeskeleton.c',
@@ -70,7 +80,6 @@ gthree_headers = [
     'gthree.h',
     'gthreeattribute.h',
     'gthreeambientlight.h',
-    'gthreearea.h',
     'gthreemeshbasicmaterial.h',
     'gthreebone.h',
     'gthreeskeleton.h',
@@ -142,7 +151,16 @@ gthree_private_headers = [
     'gthreeprivate.h',
 ]
 
+gthree_gtk3_sources = [
+    'gthreearea.c',
+]
+
+gthree_gtk3_headers = [
+    'gthreearea.h',
+]
+
 install_headers(gthree_headers, subdir: gthree_api_path)
+install_headers(gthree_gtk3_headers, subdir: gthree_gtk3_api_path)
 
 gthree_marshalers = gnome.genmarshal('gthreemarshalers',
                                      sources: 'gthreemarshalers.list',
@@ -174,7 +192,7 @@ gthree_cflags = [
 
 gthree_inc = include_directories('.')
 
-gthree_deps = [glib_dep, gobject_dep, graphene_dep, gtk_dep, json_glib_dep]
+gthree_deps = [glib_dep, gobject_dep, graphene_dep, gdkpixbuf_dep, cairo_dep, json_glib_dep]
 gthree_private_deps = [epoxy_dep, libm]
 
 libgthree = shared_library('gthree-1',
@@ -186,32 +204,58 @@ libgthree = shared_library('gthree-1',
                            include_directories: [ root_inc, gthree_inc ],
                            c_args: common_cflags + gthree_cflags,
                            link_args: common_ldflags)
+gthree_dep_sources = [gthree_typebuiltins_h]
 
-gthree_dep_sources = gthree_typebuiltins_h
+if not meson.is_cross_build() and get_option('introspection')
+   libgthree_gir = gnome.generate_gir(libgthree,
+                                      sources: gthree_sources + gthree_headers + gthree_marshalers,
+                                      namespace: 'Gthree',
+                                      nsversion: gthree_api_version,
+                                      identifier_prefix: 'Gthree',
+                                      symbol_prefix: 'gthree',
+                                      export_packages: 'gthree',
+                                      includes: [ 'GObject-2.0', 'Graphene-1.0', 'GdkPixbuf-2.0', 'cairo-1.0' ],
+                                      install: true,
+                                      extra_args: extra_gir_args)
+   gthree_dep_sources += libgthree_gir
+   libgthree_gir_dep = declare_dependency(sources: libgthree_gir)
+endif
 
 libgthree_dep = declare_dependency(sources: gthree_dep_sources,
                                    link_with: libgthree,
                                    include_directories: [gthree_inc, root_inc],
                                    dependencies: gthree_deps)
 
-if not meson.is_cross_build() and get_option('introspection')
-  extra_gir_args = [
-    '--quiet',
-    '--c-include=gthree/gthree.h',
-    '-DGTHREE_COMPILATION',
-  ]
-  if graphene_is_subproject
-    extra_gir_args = extra_gir_args + ['--add-include-path', graphene_subproject_typelib_dir]
-  endif
+gthree_gtk3_deps = [libgthree_dep, gtk3_dep]
 
-  gnome.generate_gir(libgthree,
-                     sources: gthree_sources + gthree_headers + gthree_marshalers,
-                     namespace: 'Gthree',
-                     nsversion: gthree_api_version,
-                     identifier_prefix: 'Gthree',
-                     symbol_prefix: 'gthree',
-                     export_packages: 'gthree',
-                     includes: [ 'GObject-2.0', 'Graphene-1.0', 'GdkPixbuf-2.0', 'Gdk-3.0' ],
-                     install: true,
-                     extra_args: extra_gir_args)
+libgthree_gtk3 = shared_library('gthree-gtk3-1',
+                                sources: gthree_gtk3_sources,
+                                soversion: gthree_soversion,
+                                version: gthree_libversion,
+                                install: true,
+                                dependencies: gthree_gtk3_deps,
+                                include_directories: [ root_inc, gthree_inc ],
+                                c_args: common_cflags + gthree_cflags,
+                                link_args: common_ldflags)
+gthree_gtk3_dep_sources = []
+
+if not meson.is_cross_build() and get_option('introspection')
+  libgthree_gtk3_gir = gnome.generate_gir(libgthree_gtk3,
+                                          sources: gthree_gtk3_sources + gthree_gtk3_headers,
+                                          namespace: 'GthreeGtk',
+                                          nsversion: gthree_api_version,
+                                          identifier_prefix: 'Gthree',
+                                          symbol_prefix: 'gthree',
+                                          export_packages: 'gthree',
+                                          includes: [ libgthree_gir[0], 'Gtk-3.0' ],
+                                          install: true,
+                                          dependencies: libgthree_gir_dep,
+                                          extra_args: extra_gir_args)
+   gthree_gtk3_dep_sources += libgthree_gtk3_gir
+   libgthree_gtk3_gir_dep = declare_dependency(sources: libgthree_gtk3_gir)
 endif
+
+libgthree_gtk3_dep = declare_dependency(sources: gthree_gtk3_dep_sources,
+                                        link_with: libgthree_gtk3,
+                                        include_directories: [gthree_inc, root_inc],
+                                        dependencies: gthree_gtk3_deps)

--- a/meson.build
+++ b/meson.build
@@ -18,6 +18,7 @@ gthree_binary_age = 10000 * gthree_major_version + 100 * gthree_minor_version + 
 
 gthree_api_version = '1.0'
 gthree_api_path = 'gthree-@0@/gthree'.format(gthree_api_version)
+gthree_gtk3_api_path = 'gthree-gtk3-@0@/gthree'.format(gthree_api_version)
 
 add_project_arguments('-D_GNU_SOURCE', language: 'c')
 
@@ -28,7 +29,9 @@ glib_dep       = dependency('glib-2.0', version: '>= 2.43.2')
 gobject_dep    = dependency('gobject-2.0', version: '>= 2.43.2')
 graphene_dep   = dependency('graphene-gobject-1.0', version: '>= 1.10.0',
                             fallback: ['graphene', 'graphene_dep'])
-gtk_dep        = dependency('gtk+-3.0', version: '>= 3.22')
+gdkpixbuf_dep  = dependency('gdk-pixbuf-2.0')
+cairo_dep      = dependency('cairo-gobject')
+gtk3_dep       = dependency('gtk+-3.0', version: '>= 3.22')
 epoxy_dep      = dependency('epoxy', version: '>= 1.4')
 json_glib_dep  = dependency('json-glib-1.0', version: '>= 1.2.0')
 
@@ -57,8 +60,9 @@ common_ldflags = []
 gthree_conf = configuration_data()
 gthree_conf.set_quoted('VERSION', meson.project_version())
 
-gthree_packages = ' '.join([ 'glib-2.0', 'gobject-2.0', 'graphene-gobject-1.0', 'gtk+-3.0' ])
+gthree_packages = ' '.join([ 'glib-2.0', 'gobject-2.0', 'graphene-gobject-1.0' ])
 gthree_private_packages = ' '.join([ 'epoxy', 'json-glib-1.0' ])
+gthree_gtk3_packages = ' '.join([ 'gthree-1.0', 'gtk+-3.0' ])
 
 # Compat variables for pkgconfig
 pkgconf = configuration_data()
@@ -70,8 +74,9 @@ pkgconf.set('VERSION', meson.project_version())
 pkgconf.set('srcdir', '.')
 pkgconf.set('GTHREE_PACKAGES', gthree_packages)
 pkgconf.set('GTHREE_PRIVATE_PACKAGES', gthree_private_packages)
+pkgconf.set('GTHREE_GTK3_PACKAGES', gthree_gtk3_packages)
 
-foreach pkg: [ 'gthree-1.0.pc', ]
+foreach pkg: [ 'gthree-1.0.pc', 'gthree-gtk3-1.0.pc', ]
   configure_file(input: pkg + '.in',
                  output: pkg,
                  configuration: pkgconf,


### PR DESCRIPTION
This is in preparation for supporting gtk4, as well as non-gtk use of
gthree.