### PR TITLE
Port examples to latest gtk4 (3.98.2)

### DIFF
--- a/examples/cairo.c
+++ b/examples/cairo.c
@@ -112,8 +112,9 @@ main (int argc, char *argv[])
   GthreeScene *scene;
   GthreePerspectiveCamera *camera;
   graphene_point3d_t pos;
+  gboolean done = FALSE;
 
-  window = examples_init ("Cairo textures", &box);
+  window = examples_init ("Cairo textures", &box, &done);
 
   scene = init_scene ();
   camera = gthree_perspective_camera_new (30, 1, 1, 10000);
@@ -133,7 +134,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/cubes.c
+++ b/examples/cubes.c
@@ -270,8 +270,9 @@ main (int argc, char *argv[])
   GthreeScene *scene;
   GthreePerspectiveCamera *camera;
   graphene_point3d_t pos;
+  gboolean done = FALSE;
 
-  window = examples_init ("Cubes", &box);
+  window = examples_init ("Cubes", &box, &done);
 
   scene = init_scene ();
   camera = gthree_perspective_camera_new (30, 1, 1, 10000);
@@ -291,7 +292,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/effects.c
+++ b/examples/effects.c
@@ -289,8 +289,9 @@ int
 main (int argc, char *argv[])
 {
   GtkWidget *window, *box, *hbox, *area, *check;
+  gboolean done = FALSE;
 
-  window = examples_init ("Effects", &box);
+  window = examples_init ("Effects", &box, &done);
 
   init_scene ();
   init_scene2 ();
@@ -343,7 +344,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/envmap.c
+++ b/examples/envmap.c
@@ -152,8 +152,9 @@ main (int argc, char *argv[])
   GthreeScene *scene;
   graphene_point3d_t pos;
   GtkEventController *motion;
+  gboolean done = FALSE;
 
-  window = examples_init ("Environment map", &box);
+  window = examples_init ("Environment map", &box, &done);
 
   scene = init_scene ();
   camera = gthree_perspective_camera_new (30, 1, 1, 5000);
@@ -176,7 +177,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/gtklogo.c
+++ b/examples/gtklogo.c
@@ -237,8 +237,9 @@ main (int argc, char *argv[])
   GthreeScene *scene;
   GthreePerspectiveCamera *camera;
   graphene_point3d_t pos;
+  gboolean done = FALSE;
 
-  window = examples_init ("GTK+ logo", &box);
+  window = examples_init ("GTK+ logo", &box, &done);
 
   scene = init_scene ();
   camera = gthree_perspective_camera_new (30, 1, 1, 10000);
@@ -258,7 +259,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/interactive.c
+++ b/examples/interactive.c
@@ -228,8 +228,9 @@ main (int argc, char *argv[])
   GthreeScene *scene;
   graphene_point3d_t pos;
   GtkEventController *motion;
+  gboolean done = FALSE;
 
-  window = examples_init ("Interactive", &box);
+  window = examples_init ("Interactive", &box, &done);
 
   scene = init_scene ();
   camera = gthree_perspective_camera_new (70, 1, 1, 10000);
@@ -252,7 +253,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/materials.c
+++ b/examples/materials.c
@@ -280,7 +280,11 @@ tick (GtkWidget     *widget,
   static gint64 first_frame_time = 0;
   float angle;
   graphene_vec3_t color;
+#ifdef USE_GTK4
+  float r, g, b;
+#else
   double r, g, b;
+#endif
 
   frame_time = gdk_frame_clock_get_frame_time (frame_clock);
   if (first_frame_time == 0)
@@ -347,8 +351,9 @@ int
 main (int argc, char *argv[])
 {
   GtkWidget *window, *box, *area;
+  gboolean done = FALSE;
 
-  window = examples_init ("Materials", &box);
+  window = examples_init ("Materials", &box, &done);
 
   init_scene ();
   area = gthree_area_new (scene, GTHREE_CAMERA (camera));
@@ -362,7 +367,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/model.c
+++ b/examples/model.c
@@ -491,6 +491,7 @@ main (int argc, char *argv[])
 #ifdef USE_GTK4
   GtkEventController *scroll;
 #endif
+  gboolean done = FALSE;
 
   struct {
     char *path;
@@ -515,7 +516,7 @@ main (int argc, char *argv[])
       g_ptr_array_add (env_maps, cube_texture);
     }
 
-  window = examples_init ("Models", &box);
+  window = examples_init ("Models", &box, &done);
 
   area = gthree_area_new (NULL, NULL);
 
@@ -613,7 +614,8 @@ main (int argc, char *argv[])
 
   update_scene (GTHREE_AREA (area));
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/morphtargets.c
+++ b/examples/morphtargets.c
@@ -99,8 +99,9 @@ main (int argc, char *argv[])
   GthreeScene *scene;
   GthreePerspectiveCamera *camera;
   graphene_point3d_t pos;
+  gboolean done = FALSE;
 
-  window = examples_init ("Morph targets", &box);
+  window = examples_init ("Morph targets", &box, &done);
 
   scene = init_scene ();
   camera = gthree_perspective_camera_new (30, 1, 1, 10000);
@@ -120,7 +121,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/multi.c
+++ b/examples/multi.c
@@ -185,8 +185,9 @@ main (int argc, char *argv[])
   graphene_point3d_t pos;
   graphene_euler_t euler;
   GtkEventController *click;
+  gboolean done = FALSE;
 
-  window = examples_init ("Multi views", &box);
+  window = examples_init ("Multi views", &box, &done);
 
   scene = init_scene ();
 
@@ -258,7 +259,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/normals.c
+++ b/examples/normals.c
@@ -157,8 +157,9 @@ main (int argc, char *argv[])
   GthreeScene *scene;
   GthreePerspectiveCamera *camera;
   graphene_point3d_t pos;
+  gboolean done = FALSE;
 
-  window = examples_init ("Normals", &box);
+  window = examples_init ("Normals", &box, &done);
 
   scene = init_scene ();
   camera = gthree_perspective_camera_new (30, 1, 1, 10000);
@@ -178,7 +179,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/performance.c
+++ b/examples/performance.c
@@ -120,8 +120,9 @@ main (int argc, char *argv[])
   GthreeScene *scene;
   graphene_point3d_t pos;
   GtkEventController *motion;
+  gboolean done = FALSE;
 
-  window = examples_init ("Performance", &box);
+  window = examples_init ("Performance", &box, &done);
 
   scene = init_scene ();
   camera = gthree_perspective_camera_new (60, 1, 1, 10000);
@@ -144,7 +145,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/points.c
+++ b/examples/points.c
@@ -161,8 +161,9 @@ main (int argc, char *argv[])
   GthreeScene *scene;
   GthreePerspectiveCamera *camera;
   graphene_point3d_t pos;
+  gboolean done = FALSE;
 
-  window = examples_init ("Points", &box);
+  window = examples_init ("Points", &box, &done);
 
   scene = init_scene ();
   camera = gthree_perspective_camera_new (27, 1, 5, 3500);
@@ -182,7 +183,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/properties.c
+++ b/examples/properties.c
@@ -253,9 +253,10 @@ main (int argc, char *argv[])
   GthreeScene *scene;
   GthreePerspectiveCamera *camera;
   graphene_point3d_t pos;
+  gboolean done = FALSE;
   int i;
 
-  window = examples_init ("Properties", &box);
+  window = examples_init ("Properties", &box, &done);
 
   scene = init_scene ();
   camera = gthree_perspective_camera_new (30, 1, 1, 10000);
@@ -295,7 +296,8 @@ main (int argc, char *argv[])
 
   update_property_pane ();
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/rendertarget.c
+++ b/examples/rendertarget.c
@@ -136,8 +136,9 @@ int
 main (int argc, char *argv[])
 {
   GtkWidget *window, *box, *area;
+  gboolean done = FALSE;
 
-  window = examples_init ("Render targets", &box);
+  window = examples_init ("Render targets", &box, &done);
 
   init_scene ();
 
@@ -153,7 +154,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/shader.c
+++ b/examples/shader.c
@@ -280,8 +280,9 @@ main (int argc, char *argv[])
   GthreeScene *scene;
   GthreePerspectiveCamera *camera;
   graphene_point3d_t pos;
+  gboolean done = FALSE;
 
-  window = examples_init ("Shaders", &box);
+  window = examples_init ("Shaders", &box, &done);
 
   scene = init_scene ();
   camera = gthree_perspective_camera_new (30, 1, 1, 10000);
@@ -301,7 +302,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/shadow.c
+++ b/examples/shadow.c
@@ -193,8 +193,9 @@ int
 main (int argc, char *argv[])
 {
   GtkWidget *window, *box, *area;
+  gboolean done = FALSE;
 
-  window = examples_init ("Shadows", &box);
+  window = examples_init ("Shadows", &box, &done);
 
   init_scene ();
   area = gthree_area_new (scene, GTHREE_CAMERA (camera));
@@ -209,7 +210,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/skinning.c
+++ b/examples/skinning.c
@@ -224,8 +224,9 @@ main (int argc, char *argv[])
   graphene_point3d_t pos;
   GthreeAmbientLight *ambient_light;
   GthreeDirectionalLight *directional_light;
+  gboolean done = FALSE;
 
-  window = examples_init ("Skinning", &box);
+  window = examples_init ("Skinning", &box, &done);
 
   scene = init_scene ();
 
@@ -257,7 +258,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/sprites.c
+++ b/examples/sprites.c
@@ -349,8 +349,9 @@ main (int argc, char *argv[])
   GtkWidget *window, *box, *area;
   GthreeScene *scene;
   graphene_point3d_t pos;
+  gboolean done = FALSE;
 
-  window = examples_init ("Sprites", &box);
+  window = examples_init ("Sprites", &box, &done);
 
   scene = init_scene (window);
   camera = gthree_perspective_camera_new (60, 1, 1, 2100);
@@ -378,7 +379,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/testanimation.c
+++ b/examples/testanimation.c
@@ -131,8 +131,9 @@ main (int argc, char *argv[])
   GthreeScene *scene;
   GthreePerspectiveCamera *camera;
   graphene_point3d_t pos;
+  gboolean done = FALSE;
 
-  window = examples_init ("Animations", &box);
+  window = examples_init ("Animations", &box, &done);
 
   scene = init_scene ();
   camera = gthree_perspective_camera_new (30, 1, 1, 10000);
@@ -152,7 +153,8 @@ main (int argc, char *argv[])
 
   gtk_widget_show (window);
 
-  gtk_main ();
+  while (!done)
+    g_main_context_iteration (NULL, TRUE);
 
   return EXIT_SUCCESS;
 }

--- a/examples/utils.c
+++ b/examples/utils.c
@@ -164,9 +164,21 @@ examples_load_gltl (const char *name, GError **error)
   return loader;
 }
 
+void
+examples_quit_cb (GtkWidget *widget,
+                  gpointer   data)
+{
+  gboolean *done = data;
+
+  *done = TRUE;
+
+  g_main_context_wakeup (NULL);
+}
+
 GtkWidget *
 examples_init (const char *title,
-               GtkWidget **box)
+               GtkWidget **box,
+               gboolean   *done)
 {
   GtkWidget *window, *outer_box, *button;
   g_autofree char *full_title = NULL;
@@ -177,7 +189,12 @@ examples_init (const char *title,
   gtk_init (NULL, NULL);
 #endif
 
+#ifdef USE_GTK4
+  window = gtk_window_new ();
+#else
   window = gtk_window_new (GTK_WINDOW_TOPLEVEL);
+#endif
+
   full_title = g_strdup_printf ("%s - %s", title,
 #ifdef USE_GTK4
                                 "gtk 4"
@@ -190,7 +207,7 @@ examples_init (const char *title,
 #ifdef USE_GTK3
   gtk_container_set_border_width (GTK_CONTAINER (window), 12);
 #endif
-  g_signal_connect (window, "destroy", G_CALLBACK (gtk_main_quit), NULL);
+  g_signal_connect (window, "destroy", G_CALLBACK (examples_quit_cb), done);
 
   outer_box = gtk_box_new (GTK_ORIENTATION_VERTICAL, FALSE);
   gtk_box_set_spacing (GTK_BOX (outer_box), 6);

--- a/examples/utils.h
+++ b/examples/utils.h
@@ -26,7 +26,8 @@ const graphene_vec3_t *dark_green (void);
 const graphene_vec3_t *orange (void);
 
 GtkWidget *examples_init (const char *title,
-                          GtkWidget **box);
+                          GtkWidget **box,
+                          gboolean   *done);
 GtkEventController *motion_controller_for (GtkWidget *widget);
 GtkEventController *click_controller_for (GtkWidget *widget);
 GtkEventController *scroll_controller_for (GtkWidget *widget);


### PR DESCRIPTION
Tested with GTK 4 3.98.2: gtk_main() and gtk_main_quit() have been dropped, gtk_window_new() doesn't accept type argument and gtk_hsv_to_rgb() now uses floats.