### PR TITLE
Add a build option for examples

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -117,8 +117,9 @@ configure_file(output: 'config.h', configuration: gthree_conf)
 root_inc = include_directories('.')
 
 subdir('gthree')
-subdir('examples')
-
+if get_option('examples')
+  subdir('examples')
+endif
 if get_option('gtk_doc')
   subdir('docs')
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -19,3 +19,8 @@ option('shared_lib',
        description: 'Whether to build a shared library',
        type: 'boolean',
        value: true)
+
+option('examples',
+       description : 'Whether to build example programs',
+       type: 'boolean',
+       value: true)


### PR DESCRIPTION
Set to `true` by default, useful then building Gthree as a Meson subproject.