### PR TITLE
Fix builds on Windows (using clang-cl)

### DIFF
--- a/examples/meson.build
+++ b/examples/meson.build
@@ -46,11 +46,19 @@ libexample_sources = [
   'orbitcontrols.c',
 ] + example_resources
 
+example_c_args = []
+
+if cc.get_argument_syntax() == 'msvc'
+  example_c_args += '-D_USE_MATH_DEFINES'
+endif
+
 if get_option('gtk3')
+  example_gtk3_c_args = example_c_args + [ '-DUSE_GTK3' ]
+
   libexample_gtk3 = static_library(
     'libexample-gtk3',
     libexample_sources,
-    c_args: [ '-DUSE_GTK3' ],
+    c_args: example_gtk3_c_args,
     dependencies: [
       libgthree_gtk3_dep, libm ],
     install: false,
@@ -66,7 +74,7 @@ if get_option('gtk3')
     executable(
       '@0@-gtk3'.format(example),
       '@0@.c'.format(example),
-      c_args: [ '-DUSE_GTK3' ],
+      c_args: example_gtk3_c_args,
       dependencies: [
         libexample_gk3_dep ],
       install: false)
@@ -74,10 +82,12 @@ if get_option('gtk3')
 endif
 
 if get_option('gtk4')
+  example_gtk4_c_args = example_c_args + [ '-DUSE_GTK4' ]
+
   libexample_gtk4 = static_library(
     'libexample-gtk4',
     libexample_sources,
-    c_args: [ '-DUSE_GTK4' ],
+    c_args: example_gtk4_c_args,
     dependencies: [
       libgthree_gtk4_dep, libm ],
     install: false,
@@ -93,7 +103,7 @@ if get_option('gtk4')
     executable(
       '@0@-gtk4'.format(example),
       '@0@.c'.format(example),
-      c_args: [ '-DUSE_GTK4' ],
+      c_args: example_gtk4_c_args,
       dependencies: [
         libexample_gk4_dep],
       install: false)

--- a/gthree/gthreegeometry.h
+++ b/gthree/gthreegeometry.h
@@ -125,6 +125,7 @@ const graphene_box_t    *gthree_geometry_get_bounding_box           (GthreeGeome
 GTHREE_API
 void                     gthree_geometry_set_bounding_box           (GthreeGeometry          *geometry,
                                                                      const graphene_box_t    *box);
+GTHREE_API
 void                     gthree_geometry_compute_vertex_normals     (GthreeGeometry          *geometry);
 GTHREE_API
 void                     gthree_geometry_normalize_normals          (GthreeGeometry          *geometry);

--- a/gthree/gthreeline.h
+++ b/gthree/gthreeline.h
@@ -36,7 +36,9 @@ GTHREE_API
 GthreeLine *gthree_line_new (GthreeGeometry *geometry,
                              GthreeMaterial *material);
 
+GTHREE_API
 GthreeMaterial *gthree_line_get_material (GthreeLine *line);
+GTHREE_API
 GthreeGeometry *gthree_line_get_geometry (GthreeLine *line);
 
 G_END_DECLS

--- a/gthree/gthreeobject.h
+++ b/gthree/gthreeobject.h
@@ -103,8 +103,10 @@ const graphene_vec3_t *     gthree_object_get_up                        (GthreeO
 GTHREE_API
 void                         gthree_object_look_at                      (GthreeObject                *object,
                                                                          const graphene_vec3_t       *pos);
+GTHREE_API
 void                         gthree_object_look_at_point3d              (GthreeObject                *object,
                                                                          const graphene_point3d_t    *pos);
+GTHREE_API
 void                         gthree_object_look_at_xyz                  (GthreeObject                *object,
                                                                          float                        x,
                                                                          float                        y,

--- a/gthree/gthreerenderer.h
+++ b/gthree/gthreerenderer.h
@@ -145,6 +145,7 @@ GTHREE_API
 void                gthree_renderer_render                    (GthreeRenderer     *renderer,
                                                                GthreeScene        *scene,
                                                                GthreeCamera       *camera);
+GTHREE_API
 void                gthree_renderer_unrealize                 (GthreeRenderer     *renderer);
 
 

--- a/gthree/gthreerendertarget.h
+++ b/gthree/gthreerendertarget.h
@@ -72,10 +72,12 @@ void           gthree_render_target_set_depth_texture (GthreeRenderTarget *targe
 GTHREE_API
 void           gthree_render_target_update_mipmap     (GthreeRenderTarget *target,
                                                        GthreeRenderer *renderer);
+GTHREE_API
 void           gthree_render_target_download          (GthreeRenderTarget *target,
                                                        GthreeRenderer *renderer,
                                                        guchar     *data,
                                                        gsize       stride);
+GTHREE_API
 void           gthree_render_target_download_area     (GthreeRenderTarget *target,
                                                        GthreeRenderer *renderer,
                                                        const cairo_rectangle_int_t *area,


### PR DESCRIPTION
Hi,

This PR attempts to add a few simple fixes to build on Windows using `clang-cl`, by:

*  Ensure that the public symbols are marked with `GTHREE_API` in the public headers, so that they are exported during the build.
*  Define `_USE_MATH_DEFINES` as we are using `_M_PI` with the Visual Studio and Windows SDK headers, which are consumed by the `clang-cl`compiler.

With blessings, thank you!